### PR TITLE
[Audio] Fixed issue with progress bar, re #6799

### DIFF
--- a/addons/Audio/src/presenter.js
+++ b/addons/Audio/src/presenter.js
@@ -127,7 +127,7 @@ function AddonAudio_create(){
     };
 
     function AddonAudio_onTimeUpdateCallback() {
-        var bar_width, duration = parseInt(presenter.audio.duration, 10);
+        var bar_width, duration = presenter.audio.duration;
         duration = isNaN(duration) ? 0 : duration;
         var currentTime = presenter.audio.currentTime;
         if (presenter.configuration.displayTime) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2018-09-17 Fixed issue with Audio progress bard
 2018-09-17 Fixed conflict CSS of modules
 2018-09-14 Removing semi word from translations labels and API calls.
 2018-08-24 Fixed problem with hiding audio descriptions in Video module


### PR DESCRIPTION
Błąd objawiał się przez wyświetlenie paska postępu wykraczającego poza jego "maksymalną" szerokość i był spowodowany przez zaokrąglanie w dół długości pliku audio w trakcie obliczania nowej szerokości paska postępu.

Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/realtime_cardwall?ticket=6799