### PR TITLE
[eKeyboard] Fixing the issue with meta keys, re #6800

### DIFF
--- a/addons/eKeyboard/src/presenter.js
+++ b/addons/eKeyboard/src/presenter.js
@@ -704,7 +704,17 @@ function AddoneKeyboard_create(){
                         document.removeEventListener('mousedown', presenter.clickedOutsideCallback);
                         $(closeButtonElement).hide();
                     },
-                    accepted: function(e, keyboard, el) {},
+                    accepted: function(e, keyboard, el) {
+                        var api = $(lastClickedElement).data('keyboard');
+                        var $el = $(el);
+
+                        //Fixing the issue where if a key contains word 'meta' it will be treated as a meta key
+                        if (!api.last.val && api.last.key && api.last.key.indexOf('meta') != -1
+                            && presenter.configuration.customLayout[api.last.key] == null) {
+                            api.last.val = api.last.key;
+                            $el.val(api.last.key);
+                        }
+                    },
                     canceled: function(e, keyboard, el) {},
                     hidden: function(e, keyboard, el) {},
 

--- a/addons/eKeyboard/src/presenter.js
+++ b/addons/eKeyboard/src/presenter.js
@@ -696,6 +696,14 @@ function AddoneKeyboard_create(){
                         document.addEventListener('mousedown', presenter.clickedOutsideCallback);
                     },
                     change: function (e, keyboard, el) {
+                        var api = $(lastClickedElement).data('keyboard');
+
+                        //Fixing the issue where if a key contains word 'meta' it will be treated as a meta key
+                        if (api.last.key && api.last.key.indexOf('meta') != -1
+                            && presenter.configuration.customLayout[api.last.key] == null) {
+                            keyboard.insertText(api.last.key);
+                        }
+
                         var event = new Event('change');
                         el.dispatchEvent(event);
 
@@ -704,17 +712,7 @@ function AddoneKeyboard_create(){
                         document.removeEventListener('mousedown', presenter.clickedOutsideCallback);
                         $(closeButtonElement).hide();
                     },
-                    accepted: function(e, keyboard, el) {
-                        var api = $(lastClickedElement).data('keyboard');
-                        var $el = $(el);
-
-                        //Fixing the issue where if a key contains word 'meta' it will be treated as a meta key
-                        if (!api.last.val && api.last.key && api.last.key.indexOf('meta') != -1
-                            && presenter.configuration.customLayout[api.last.key] == null) {
-                            api.last.val = api.last.key;
-                            $el.val(api.last.key);
-                        }
-                    },
+                    accepted: function(e, keyboard, el) {},
                     canceled: function(e, keyboard, el) {},
                     hidden: function(e, keyboard, el) {},
 


### PR DESCRIPTION
Problem objawiał się przez uniemożliwienie wstawienia słów zawierających 'meta' (w tym wypadku 'metal') do gapy, tj. jeżeli spośród przycisków klawiatury naciśnięto by 'metal', nic się nie działo.

Nie udało mi się znaleźć przyczyny tego problemu w naszym kodzie, update biblioteki również nie rozwiązał problemu, w związku z tym przygotowałem obejście.

Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/6800--support--problem-w-ekeyboardzie/details?comment=1485530374