### PR TITLE
[eKeyboard] Native Virtual Keyboard doesn't appear on mobile  re #6803

### DIFF
--- a/addons/eKeyboard/src/presenter.js
+++ b/addons/eKeyboard/src/presenter.js
@@ -452,7 +452,7 @@ function AddoneKeyboard_create(){
             }
             showOpenButton();
         } else {
-            if (MobileUtils.isMobileUserAgent(navigator.userAgent)) {
+            if (MobileUtils.isMobileUserAgent(navigator.userAgent) && presenter.configuration.lockInput) {
                 // hides native keyboard
                 document.activeElement.blur();
             }
@@ -547,7 +547,7 @@ function AddoneKeyboard_create(){
                     alwaysOpen: false,
 
                     // give the preview initial focus when the keyboard becomes visible
-                    initialFocus: true,
+                    initialFocus: presenter.configuration.lockInput,
 
                     // if true, keyboard will remain open even if the input loses focus.
                     stayOpen: true,


### PR DESCRIPTION
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/realtime_cardwall?ticket=6803
Wersja testowa: http://test-6803.mauthor-dev.appspot.com/embed/5513757119741952

Jeżeli do modułu Text dołączona jest eKeyboard, na urządzeniach mobilnych nie pojawiała się natywna klawiatura wirtualna, nawet jeśli property "Lock Standard Keyboard Input" było odznaczone.