### PR TITLE
[Editor] Added missing split page label, re #6709

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2018-09-24 Added missing split page label
 2018-09-19 Fixed issue with decimals in Math
 2018-09-19 Unifed visiblity settings in preview for multiple addons
 2018-09-17 Fixed issue with Audio progress bard

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/com/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/com/dictionary.js
@@ -235,6 +235,7 @@ var ice_dictionary_en = {
 	"delete_chapter_confirmation" : "You are going to delete chapter:\n ",
 	"delete_chapter_pages_confirmation" : "Do you want to delete all elements in chapter?",
 	"split_page_confirmation" : "Do you want to split this page?",
+	"split_page_not_possible" : "Split page is not possible",
 	"delete_module_confirmation" : "Do you want to remove selected modules?",
 	"cant_remove_last_page" : "Can't remove page.\nYou need at least one page in presentation",
 	"rename_page" : "Rename page",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/fr/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/fr/dictionary.js
@@ -235,6 +235,7 @@ var ice_dictionary_fr = {
     "delete_chapter_confirmation" : "Vous allez supprimer le chapitre :\n ",
     "delete_chapter_pages_confirmation" : "Do you want to delete all elements in chapter?",
     "split_page_confirmation" : "Voulez-vous diviser cette page ?",
+	"split_page_not_possible" : "Split page is not possible",
     "delete_module_confirmation" : "Voulez-vous supprimer les modules sélectionnés ?",
     "cant_remove_last_page" : "Impossible de supprimer la page.\n Vous devez au moins mettre une page dans la présentation",
     "rename_page" : "Renommer la page",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/mx/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/mx/dictionary.js
@@ -235,6 +235,7 @@ var ice_dictionary_mx = {
 	"delete_chapter_confirmation": "Vas a eliminar el capítulo:\n ",
     "delete_chapter_pages_confirmation" : "¿Deseas eliminar todos los elementos del capítulo?",
 	"split_page_confirmation": "¿Quieres dividir esta página?",
+	"split_page_not_possible" : "Split page is not possible",
 	"delete_module_confirmation": "¿Quieres eliminar los módulos seleccionados?",
 	"cant_remove_last_page": "No se puede eliminar la página \n. La presentación debe tener al menos una página.",
 	"rename_page": "Renombrar página",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/pl/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/pl/dictionary.js
@@ -235,6 +235,7 @@ var ice_dictionary_pl = {
 	"delete_chapter_confirmation" : "Zamierzasz usunąć rozdział:\n ",
 	"delete_chapter_pages_confirmation" : "Czy usunąć wszystkie elementy zawarte w rozdziale?",
 	"split_page_confirmation" : "Czy chcesz podzielić tę stronę?",
+	"split_page_not_possible" : "Split page is not possible",
 	"delete_module_confirmation" : "Czy chcesz usunąć zaznaczone moduły?",
 	"cant_remove_last_page" : "Nie można usunąć strony.\nPrezentacja musi zawierać co najmniej jedną stronę.",
 	"rename_page" : "Zmień nazwę strony",


### PR DESCRIPTION
Ticket https://learneticsa.assembla.com/spaces/lorepo/tickets/realtime_cardwall?ticket=6709

Dodałem brakującą labelkę informującą, że split page nie może zostać wykonany (przykładowy sposób odtworzenia błędu - Utworzenie grupy modułów a następnie próba wykonania split page tak, że niektóre moduły grupy znalazłyby się na różnych stronach. ).