### PR TITLE
Fix issue with mathjax in text #6839

### DIFF
--- a/addons/eKeyboard/src/presenter.js
+++ b/addons/eKeyboard/src/presenter.js
@@ -999,7 +999,7 @@ function AddoneKeyboard_create(){
 
 
     presenter.destroy = function destroy_addon_eKeyboard_function () {
-        if (presenter.isPreview) {
+        if (presenter.isPreview || !presenter.configuration) {
             return;
         }
 

--- a/addons/eKeyboard/test/DestroyTests.js
+++ b/addons/eKeyboard/test/DestroyTests.js
@@ -1,0 +1,29 @@
+TestCase("[eKeyboard] Destroying keyboard tests", {
+   setUp: function () {
+       this.presenter = AddoneKeyboard_create();
+	   this.presenter.keyboardWrapper = document.createElement('div');
+	   this.presenter.view = document.createElement('div');
+   },
+
+    "test while configuration is not set when destroy is called then method should stop": function () {
+
+		var first = true;
+		var calledMultipleTimes = false;
+
+		Object.defineProperty(this.presenter,'configuration', {get: function() {
+			if (first) {
+			    // on first call, act as if configuration is empty
+				first = false;
+				return null;
+			}
+			calledMultipleTimes = true;
+			// otherwise return stub
+			return {$inputs: $('div')};
+		}});
+		var openButtonElement = document.createElement('div');
+
+		this.presenter.destroy();
+
+        assertFalse(calledMultipleTimes);
+    },
+});

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2019-10-05 Fixed issue with MathJax in eKeyboard and Text when the first layout is not default
 2019-10-02 Fixed isAttempted method in not activity mode in True False module
 2019-09-27 Changed mouse and touch control scheme in Catch addon
 2018-09-24 Fixed issues with scoring in multiplegap

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
@@ -54,6 +54,24 @@ public class TextView extends HTML implements IDisplay, IWCAG, IWCAGModuleView {
 		}
 		
 		getElement().setAttribute("lang", this.module.getLangAttribute());
+		if (this.module.hasMathGaps()) {
+			setCallbackForMathJaxLoaded(this, getElement());
+		}
+	}
+	
+	private native void setCallbackForMathJaxLoaded(TextView x, Element e) /*-{
+		var $e = $wnd.$(e);
+		$e.css('display','none');
+		$wnd.MathJax.Hub.Register.MessageHook("End Process", function mathJaxResolve(message) {
+	        if ($wnd.$(message[1]).hasClass('ic_page')) {
+	            x.@com.lorepo.icplayer.client.module.text.TextView::mathJaxIsLoadedCallback()();
+	            $e.css('display','');
+	        }
+	    });
+	}-*/;
+	
+	void mathJaxIsLoadedCallback() {
+		this.refreshMath();
 	}
 
 	public ITextViewListener getListener() {
@@ -303,7 +321,7 @@ public class TextView extends HTML implements IDisplay, IWCAG, IWCAGModuleView {
 	public void refreshMath () {
 		MathJax.refreshMathJax(getElement());
 	}
-	
+
 	public void rerenderMathJax () {
 		MathJax.rerenderMathJax(getElement());
 	}


### PR DESCRIPTION
Poprawiono dwa błędy z MathJaxem pojawiające się na pierwszej stronie gdy pierwszy layout nie jest domyślny.
1) W eKeyboard problem z błędami gdy addon jest niszczony przed załadowaniem MathJaxa
2) W Text gdzie elementy math nie była za pierwszy razem załadowane poprawnie (pojawiał się plaintext zamiast wyniku pracy mathjax).

Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/realtime_cardwall?ticket=6839