### PR TITLE
Test 6842 fix hiding answers on get score

### DIFF
--- a/addons/Text_Selection/src/presenter.js
+++ b/addons/Text_Selection/src/presenter.js
@@ -1174,7 +1174,17 @@ function AddonText_Selection_create() {
     };
 
     function points(selector) {
-        var numbersSelected = presenter.$view.find('.text_selection').find('.selected').map(function () {
+        var $selectedElements = null;
+        if (!presenter.isShowAnswers) {
+            $selectedElements = presenter.$view.find('.text_selection').find('.selected');
+        } else {
+            if (presenter.selected_elements) {
+                $selectedElements = presenter.selected_elements;
+            } else {
+                return 0;
+            }
+        }
+        var numbersSelected = $selectedElements.map(function () {
             return parseInt(this.getAttribute('number'), 10);
         }).get();
 
@@ -1183,9 +1193,6 @@ function AddonText_Selection_create() {
 
     presenter.getErrorCount = function () {
         if (presenter.configuration.isActivity) {
-            if (presenter.isShowAnswers) {
-                presenter.hideAnswers();
-            }
             return points(presenter.markers.markedWrong);
         } else {
             return 0;
@@ -1194,9 +1201,6 @@ function AddonText_Selection_create() {
 
     presenter.getMaxScore = function () {
         if (presenter.configuration.isActivity) {
-            if (presenter.isShowAnswers) {
-                presenter.hideAnswers();
-            }
             return presenter.markers.markedCorrect.length;
         } else {
             return 0;
@@ -1205,9 +1209,6 @@ function AddonText_Selection_create() {
 
     presenter.getScore = function () {
         if (presenter.configuration.isActivity) {
-            if (presenter.isShowAnswers) {
-                presenter.hideAnswers();
-            }
             return points(presenter.markers.markedCorrect);
         } else {
             return 0;

--- a/addons/Text_Selection/test/Scoring.js
+++ b/addons/Text_Selection/test/Scoring.js
@@ -11,6 +11,10 @@ TestCase('[Text Selection] scoring tests', {
         this.presenter.configuration = {
             isActivity: true
         };
+
+        this.stubs = {
+            hideAnswers: sinon.stub(this.presenter, 'hideAnswers')
+        }
     },
 
     'test getErrorCount noerrors' : function() {
@@ -41,5 +45,32 @@ TestCase('[Text Selection] scoring tests', {
     'test getScore equals one' : function() {
         this.presenter.markers = { markedCorrect: [1, 2, 4] };
         assertEquals(1, this.presenter.getScore());
+    },
+
+    'test while showing answers when get score is called then answers are not hidden': function() {
+        this.presenter.markers = { markedCorrect: [] };
+        this.presenter.isShowAnswers = true;
+
+        this.presenter.getScore();
+
+        assertFalse(this.stubs.hideAnswers.called);
+    },
+
+    'test while showing answers when getErrorCount is called then answers are not hidden': function() {
+        this.presenter.markers = { markedWrong: [] };
+        this.presenter.isShowAnswers = true;
+
+        this.presenter.getErrorCount();
+
+        assertFalse(this.stubs.hideAnswers.called);
+    },
+
+    'test while showing answers when getMaxScore is called then answers are not hidden': function() {
+        this.presenter.markers = { markedCorrect: [] };
+        this.presenter.isShowAnswers = true;
+
+        this.presenter.getMaxScore();
+
+        assertFalse(this.stubs.hideAnswers.called);
     }
 });

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2019-10-08 Fixed issue with show answers in Text Selection when Limited Check is used
 2019-10-02 Fixed isAttempted method in not activity mode in True False module
 2019-09-27 Changed mouse and touch control scheme in Catch addon
 2018-09-24 Fixed issues with scoring in multiplegap


### PR DESCRIPTION
Wersja testowa: https://test-6842-dot-mauthor-dev.appspot.com/embed/5093236922122240
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/realtime_cardwall?ticket=6842

W addonie Text Selection tryb show answers był wyłączany w momencie, gdy inny addon wywołał jej metodę getScore, getMaxScore lub getErrorsCount (błąd został zauważony na przykłądzie addonu Limited Check).