### PR TITLE
[MathJax] Clearing added hooks after modules removal. RFD #6885

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,10 @@
+2018-11-02 Added removal of MathJax "End Process" hooks after modules detach  
 2018-10-25 Fixed problem with loading math jax
 2018-10-25 Added new addon audio recorder
-201810-16 Hierarchical lesson report add maxscore link
+2018-10-16 Hierarchical lesson report add maxscore link
 2018-10-16 Added property Plate Image in Catch module
 2018-10-15 Fixed iFrame visible in the editor when the hide option is enabled
 2018-10-12 Shooting range impoving the game.
-201810-11 Removed sending ValueChanged with value removed on stopping item drag in multiplegap
 2018-10-11 Removed sending ValueChanged with value removed on stopping item drag in multiplegap
 2018-10-10 Added disable dragging property in Ordering
 2018-10-09 Fixed scoring in multiplegap when incorrect answers are present

--- a/src/main/java/com/lorepo/icplayer/client/module/choice/ChoiceView.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/choice/ChoiceView.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
@@ -41,6 +42,7 @@ public class ChoiceView extends AbsolutePanel implements ChoicePresenter.IDispla
 	private boolean isWCAGOn = false;
 	private boolean isShowErrorsMode = false;
 	private boolean mathJaxIsLoaded = false;
+	private JavaScriptObject mathJaxHook = null;
 
 	private int position = -1;
 	
@@ -128,8 +130,15 @@ public class ChoiceView extends AbsolutePanel implements ChoicePresenter.IDispla
 	}
 	
 	@Override
+	protected void onDetach() {
+		this.removeHook();
+		
+		super.onDetach();
+	};
+	
+	@Override
 	public void mathJaxLoaded() {
-		MathJax.setCallbackForMathJaxLoaded(this); 
+		this.mathJaxHook = MathJax.setCallbackForMathJaxLoaded(this);
 	}
 	    
 	@Override
@@ -474,6 +483,13 @@ public class ChoiceView extends AbsolutePanel implements ChoicePresenter.IDispla
 	private void speak (List<TextToSpeechVoice> voiceTexts) {
 		if (this.pageController != null) {	
 			this.pageController.speak(voiceTexts);
+		}
+	}
+
+	@Override
+	public void removeHook() {
+		if (this.mathJaxHook != null) {
+			MathJax.removeMessageHookCallback(this.mathJaxHook);
 		}
 	}
 

--- a/src/main/java/com/lorepo/icplayer/client/module/ordering/OrderingView.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/ordering/OrderingView.java
@@ -61,6 +61,7 @@ public class OrderingView extends Composite implements IDisplay, IWCAG, IWCAGMod
 	private boolean isWCAGOn = false;
 	private PageController pageController;
 	static public String WCAG_SELECTED_CLASS_NAME = "keyboard_navigation_active_element";
+	private JavaScriptObject mathJaxHook = null;
 	
 	private final String ITEM_CORRECT_CLASS = "ic_ordering-item-correct";
 	private final String ITEM_WRONG_CLASS = "ic_ordering-item-wrong";
@@ -142,7 +143,7 @@ public class OrderingView extends Composite implements IDisplay, IWCAG, IWCAGMod
 	
 	@Override
 	public void mathJaxLoaded() {
-		MathJax.setCallbackForMathJaxLoaded(this); 
+		this.mathJaxHook = MathJax.setCallbackForMathJaxLoaded(this);
 	}
 	
 	private boolean isDisableDragging() {
@@ -925,6 +926,20 @@ public class OrderingView extends Composite implements IDisplay, IWCAG, IWCAGMod
 		if (this.pageController != null) {
 			this.pageController.speak(textVoices);
 		}
+	}
+	
+	@Override
+	protected void onDetach() {
+		this.removeHook();
+		
+		super.onDetach();
+	};
+
+	@Override
+	public void removeHook() {
+		if (this.mathJaxHook != null) {
+			MathJax.removeMessageHookCallback(this.mathJaxHook);
+		}		
 	}
 	
 }

--- a/src/main/java/com/lorepo/icplayer/client/module/sourcelist/SourceListView.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/sourcelist/SourceListView.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 
+import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
@@ -49,7 +50,8 @@ public class SourceListView extends FlowPanel implements IDisplay, IWCAG, IWCAGM
 	private PageController pageController;
 	private boolean isWCAGOn = false;
 	private boolean mathJaxIsLoaded = false;
-
+	private JavaScriptObject mathJaxHook = null;
+	
 	public SourceListView(SourceListModule module, boolean isPreview){
 		this.module = module;
 		createUI(isPreview);
@@ -81,7 +83,7 @@ public class SourceListView extends FlowPanel implements IDisplay, IWCAG, IWCAGM
 
 	@Override
 	public void mathJaxLoaded() {
-		MathJax.setCallbackForMathJaxLoaded(this); 
+		this.mathJaxHook = MathJax.setCallbackForMathJaxLoaded(this);
 	}
 	
 	@Override
@@ -493,5 +495,19 @@ public class SourceListView extends FlowPanel implements IDisplay, IWCAG, IWCAGM
 	@Override
 	public String getLang () {
 		return this.module.getLangAttribute();
+	}
+	
+	@Override
+	protected void onDetach() {
+		this.removeHook();
+		
+		super.onDetach();
+	};
+
+	@Override
+	public void removeHook() {
+		if (this.mathJaxHook != null) {
+			MathJax.removeMessageHookCallback(this.mathJaxHook);
+		}		
 	}
 }

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
@@ -629,6 +629,7 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 	public void removeHook() {
 		if (this.mathJaxHook != null) {
 			MathJax.removeMessageHookCallback(this.mathJaxHook);
+			this.mathJaxHook = null;
 		}
 	}
 	

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 
+import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.KeyDownEvent;
@@ -36,6 +37,7 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 	private boolean isWCAGon = false;
 	private boolean isShowErrorsMode = false;
 	private boolean mathJaxIsLoaded = false;
+	private JavaScriptObject mathJaxHook = null;
 	
 	public TextView (TextModel module, boolean isPreview) {
 		this.module = module;
@@ -45,7 +47,7 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 
 	@Override
 	public void mathJaxLoaded() {
-		MathJax.setCallbackForMathJaxLoaded(this); 
+		this.mathJaxHook = MathJax.setCallbackForMathJaxLoaded(this); 
 	}
 	
 	private void createUI (boolean isPreview) {
@@ -613,6 +615,20 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 	private void speak (List<TextToSpeechVoice> textVoices) {
 		if (this.pageController != null && this.isWCAGon) {
 			this.pageController.speak(textVoices);
+		}
+	}
+	
+	@Override
+	protected void onDetach() {		
+		this.removeHook();
+		
+		super.onDetach();
+	};
+
+	@Override
+	public void removeHook() {
+		if (this.mathJaxHook != null) {
+			MathJax.removeMessageHookCallback(this.mathJaxHook);
 		}
 	}
 	

--- a/src/main/java/com/lorepo/icplayer/client/utils/MathJax.java
+++ b/src/main/java/com/lorepo/icplayer/client/utils/MathJax.java
@@ -1,5 +1,6 @@
 package com.lorepo.icplayer.client.utils;
 
+import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.dom.client.Element;
 
 public class MathJax {
@@ -21,11 +22,21 @@ public class MathJax {
 		$wnd.MathJax.Hub.Rerender(e);
 	}-*/;
 	
-	public static native void setCallbackForMathJaxLoaded(MathJaxElement element) /*-{
-		$wnd.MathJax.Hub.Register.MessageHook("End Process", function mathJaxResolve(message) {
+	public static native JavaScriptObject setCallbackForMathJaxLoaded(MathJaxElement element) /*-{
+		return $wnd.MathJax.Hub.Register.MessageHook("End Process", function mathJaxResolve(message) {
 	        if ($wnd.$(message[1]).hasClass('ic_page')) {
 	            element.@com.lorepo.icplayer.client.utils.MathJaxElement::mathJaxIsLoadedCallback()();
 	        }
 	    });
+	}-*/;
+	
+	public static native void removeMessageHookCallback(JavaScriptObject hook) /*-{
+		// https://github.com/mathjax/MathJax-docs/wiki/How-to-stop-listening-or-un-register-from-a-messagehook
+		setTimeout( 
+			function removeHook() {
+				$wnd.MathJax.Hub.signal.hooks["End Process"].Remove(hook)
+			}, 
+			0
+		);
 	}-*/;
 }

--- a/src/main/java/com/lorepo/icplayer/client/utils/MathJax.java
+++ b/src/main/java/com/lorepo/icplayer/client/utils/MathJax.java
@@ -34,7 +34,7 @@ public class MathJax {
 		// https://github.com/mathjax/MathJax-docs/wiki/How-to-stop-listening-or-un-register-from-a-messagehook
 		setTimeout( 
 			function removeHook() {
-				$wnd.MathJax.Hub.signal.hooks["End Process"].Remove(hook)
+				$wnd.MathJax.Hub.signal.hooks["End Process"].Remove(hook);
 			}, 
 			0
 		);

--- a/src/main/java/com/lorepo/icplayer/client/utils/MathJaxElement.java
+++ b/src/main/java/com/lorepo/icplayer/client/utils/MathJaxElement.java
@@ -4,5 +4,6 @@ public interface MathJaxElement {
 	public void mathJaxLoaded();
 	public void mathJaxIsLoadedCallback(); 
 	public void refreshMath();
+	public void removeHook();
 
 }


### PR DESCRIPTION
MR #222 introduced a optimization problem - added hooks callbacks weren't removed after module has been removed (i.e after page change). In lesson editor this caused massive lags after changing property of modules.
This fix adds removal of hooks in onDetach method of modules.