### PR TITLE
[MathJax] Fix for double mathjax render when changing layouts #7004

### DIFF
--- a/src/main/java/com/lorepo/icplayer/client/utils/MathJax.java
+++ b/src/main/java/com/lorepo/icplayer/client/utils/MathJax.java
@@ -10,9 +10,20 @@ public class MathJax {
 	 */
 	public static native void refreshMathJax(Element e) /*-{
 		try {
-			$wnd.MathJax.Callback.Queue().Push(function () {
-				$wnd.MathJax.Hub.Typeset(e);
-			});
+			// Array is created this way, beacuse in different frames Array prototypes are different objects.
+			// Comparing array variable from one frame to Array prototype in different frame will return false
+            // GWT creates its own frame and MathJax is placed in other ($wnd)
+			// ex (when window !== top):
+			// var array = new Array(); 
+			// array instanceof Array // true
+			// array instanceof top.Array // false
+
+			var args = new $wnd.Array();
+			args.push("Typeset", $wnd.MathJax.Hub, e);
+
+			// This adds command to MathJax internal queue and assures all callbacks will be called one after another
+			// Calling MathJax.Callback.Queue() creates a new queue every time, so it shouldn't be used for rerendering purporses 
+			$wnd.MathJax.Hub.Queue(args);
 	  	} catch(err) {
 	  		console.log("Error : " + err);
 		}

--- a/src/main/java/com/lorepo/icplayer/client/utils/MathJax.java
+++ b/src/main/java/com/lorepo/icplayer/client/utils/MathJax.java
@@ -10,10 +10,11 @@ public class MathJax {
 	 */
 	public static native void refreshMathJax(Element e) /*-{
 		try {
-			// Array is created this way, beacuse in different frames Array prototypes are different objects.
-			// Comparing array variable from one frame to Array prototype in different frame will return false
-            // GWT creates its own frame and MathJax is placed in other ($wnd)
-			// ex (when window !== top):
+			// Array is created this way, beacuse in different windows Array prototypes are different objects.
+			// Comparing array variable from one window to Array prototype in different window will return false
+            // GWT creates its own window and MathJax is placed in another ($wnd)
+            // This is needed because MathJax compares arguments to instaceof Array
+			// e.g. (when window !== top):
 			// var array = new Array(); 
 			// array instanceof Array // true
 			// array instanceof top.Array // false


### PR DESCRIPTION
The problem was with refreshMathJax function - calling $wnd.MathJax.Callback.Queue() created queue to which one task was pushed. Calling refreshMathJax more than one caused creation of many queues which were doing the same thing (again remaking MathJax typeset process). Typeset process consists of many asynchronous task, so there was possibility that, same phases of process were done one after another, which caused double render.
After this fix, all typesetting commands are added to internal MathJax queue, which guarantees that tasks will be done one after another and after each single task has finshed - in case of Typeset function, after successful rerendering.