### PR TITLE
[SourceList] Fix for not restoring dragged item after returning it from Text, #7018

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2019-02-21 Fix for problem with dissapearing Source List items after drag stop
 2019-02-08 Fixed adding selectable characters in word in Text Coloring
 2019-01-31 Added starting values to connection modules
 2019-01-28 Fixed problem with recreating gaps on show command

--- a/src/main/java/com/lorepo/icplayer/client/module/sourcelist/SourceListView.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/sourcelist/SourceListView.java
@@ -136,10 +136,6 @@ public class SourceListView extends FlowPanel implements IDisplay, IWCAG, IWCAGM
 		}
 
 		connectLabelEventHandlers(label, id);
-
-        if(!isPreview){
-    		JavaScriptUtils.makeDraggable(label.getElement(), presenter.getAsJavaScript());
-        }
 	}
 
 	public void connectLabelEventHandlers(HTML label, final String id) {
@@ -175,6 +171,10 @@ public class SourceListView extends FlowPanel implements IDisplay, IWCAG, IWCAGM
 				itemDragged(id);
 			}
 		});
+
+        if(!isPreview){
+    		JavaScriptUtils.makeDraggable(label.getElement(), presenter.getAsJavaScript());
+        }
 	}
 
 	@Override

--- a/src/main/java/com/lorepo/icplayer/client/module/sourcelist/SourceListView.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/sourcelist/SourceListView.java
@@ -90,8 +90,9 @@ public class SourceListView extends FlowPanel implements IDisplay, IWCAG, IWCAGM
 		isDragged = false;
 	
 		if (this.labelToRemove != null && this.idOfLabelToRemove != null) {
-			this.removeItem(this.idOfLabelToRemove);
+			labelsIds.remove(this.idOfLabelToRemove);
 			this.remove(this.labelToRemove);
+
 			this.labelToRemove = null;
 			this.idOfLabelToRemove = null;
 		}
@@ -134,6 +135,14 @@ public class SourceListView extends FlowPanel implements IDisplay, IWCAG, IWCAGM
 			refreshMath(label.getElement());
 		}
 
+		connectLabelEventHandlers(label, id);
+
+        if(!isPreview){
+    		JavaScriptUtils.makeDraggable(label.getElement(), presenter.getAsJavaScript());
+        }
+	}
+
+	public void connectLabelEventHandlers(HTML label, final String id) {
 		label.addTouchEndHandler(new TouchEndHandler() {
 			@Override
 			public void onTouchEnd(TouchEndEvent event) {
@@ -166,10 +175,6 @@ public class SourceListView extends FlowPanel implements IDisplay, IWCAG, IWCAGM
 				itemDragged(id);
 			}
 		});
-
-        if(!isPreview){
-    		JavaScriptUtils.makeDraggable(label.getElement(), presenter.getAsJavaScript());
-        }
 	}
 
 	@Override

--- a/src/test/java/com/lorepo/icplayer/client/module/sourcelist/GWTSourceListViewTestCase.java
+++ b/src/test/java/com/lorepo/icplayer/client/module/sourcelist/GWTSourceListViewTestCase.java
@@ -1,0 +1,81 @@
+package com.lorepo.icplayer.client.module.sourcelist;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+
+import com.google.gwt.user.client.ui.HTML;
+import com.googlecode.gwt.test.GwtModule;
+import com.googlecode.gwt.test.GwtTest;
+
+@GwtModule("com.lorepo.icplayer.Icplayer")
+public class GWTSourceListViewTestCase extends GwtTest {
+	private SourceListModule module;
+	private SourceListView view;
+	
+	private List<String> itemsLabels;
+	private List<String> itemsID;
+	
+	private boolean isPreview = true;
+	
+	@Before
+	public void setUp() throws Exception {
+		this.module = new SourceListModule();
+		this.view = PowerMockito.spy(new SourceListView(this.module, this.isPreview));
+		
+		PowerMockito.doNothing().when(this.view).connectLabelEventHandlers(Matchers.any(HTML.class), Matchers.anyString());
+		
+		this.createItems();
+	}
+	
+	private void createItems() {
+		String[] ids = new String[] {"item1ID", "item2ID", "item3ID", "item4ID"};
+		String[] values = new String[] {"item1", "item2", "item3", "item3"};
+		
+		this.itemsID = Arrays.asList(ids);
+		this.itemsLabels = Arrays.asList(values);
+		
+
+		for (int i = 0; i < this.itemsID.size(); i++) {
+			this.view.addItem(this.itemsID.get(i), this.itemsLabels.get(i), this.isPreview);
+		}
+	}
+	
+	@Test
+	public void givenFourItemsInSourceListWhenRemovingLabelThenThreeItemsRemains() {
+		assertEquals(this.itemsID.size(), this.view.getCurrentLabels().size());
+		
+		String idOfLabelToRemove = this.itemsID.get(1);
+
+		this.view.setDragMode();		
+		this.view.removeItem(idOfLabelToRemove);
+		this.view.unsetDragMode();
+		
+		int childElementsCount = this.view.getElement().getChildCount();
+		
+		assertEquals(this.itemsID.size() - 1, childElementsCount);
+	}
+	
+	@Test
+	public void givenFourLabelsAndTwoItemsWithSameLabelInSourceListWhenRemovingLabelThenThreeItemsRemains() {
+		assertEquals(this.itemsID.size(), this.view.getCurrentLabels().size());
+		
+		String idOfLabelToRemove = this.itemsID.get(3);
+
+		this.view.setDragMode();		
+		this.view.removeItem(idOfLabelToRemove);
+		this.view.unsetDragMode();
+
+		int childElementsCount = this.view.getElement().getChildCount();
+		
+		assertEquals(this.itemsID.size() - 1, childElementsCount);
+	}
+
+}


### PR DESCRIPTION
After text has returned one item and drag ended in source list there were two items with same label, which were removed in unsetDragMode function - but only one of them should be removed.
Changing the call from removeItem to removing item from ids list, fixes the problem, while still maitaining original fix for handling dragging and keyboard navigation.