### PR TITLE
Fixed issue with dropdown gap editor, re #7101

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+1019-03-13 Fixed issue with dropdown gap editor when 'keep in order' is disabled
 2019-03-06 Fixed problem with not selectable placeholder text in filled gap after reset command
 2019-03-04 Added showAnswers, hideAnswers, enable and disable commands in True False module
 2019-02-28 Fixed problem with setting state in Text Audio module

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextModel.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextModel.java
@@ -58,6 +58,7 @@ public class TextModel extends BasicModuleModel implements IWCAGModuleModel {
 	private boolean blockWrongAnswers = false;
 	private boolean userActionEvents = false;
 	private boolean useEscapeCharacterInGap = false;
+	private boolean syntaxError = false;
 	private String originalText;
 	private ArrayList<SpeechTextsStaticListItem> speechTextItems = new ArrayList<SpeechTextsStaticListItem>();
 	private String langAttribute = "";
@@ -186,6 +187,7 @@ public class TextModel extends BasicModuleModel implements IWCAGModuleModel {
 		gapInfos = parsedTextInfo.gapInfos;
 		choiceInfos = parsedTextInfo.choiceInfos;
 		linkInfos = parsedTextInfo.linkInfos;
+		syntaxError = parsedTextInfo.hasSyntaxError;
 		if (getBaseURL() != null) {
 			parsedText = StringUtils.updateLinks(parsedText, getBaseURL());
 		}
@@ -1036,4 +1038,7 @@ public class TextModel extends BasicModuleModel implements IWCAGModuleModel {
 		return this.originalText;
 	}
 	
+	public boolean hasSyntaxError () {
+		return syntaxError;
+	}
 }

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
@@ -9,6 +9,7 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.HTML;
 import com.lorepo.icf.utils.StringUtils;
 import com.lorepo.icf.utils.TextToSpeechVoice;
+import com.lorepo.icf.utils.i18n.DictionaryWrapper;
 import com.lorepo.icplayer.client.framework.module.StyleUtils;
 import com.lorepo.icplayer.client.module.IWCAG;
 import com.lorepo.icplayer.client.module.IWCAGModuleView;
@@ -39,6 +40,7 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 	private boolean mathJaxIsLoaded = false;
 	private JavaScriptObject mathJaxHook = null;
 	private String originalDisplay = "";
+	private boolean isPreview = false;
 	
 	// because of bug (#4498, commit b4c6f7ea1f4a299dc411de1cff408549aa22bf54) FilledGapWidgets aren't added to textElements array as FilledGapWidgets, but as GapWidgets (check connectFilledGaps vs connectGaps)
 	// later this causes issues with inheritance in reconnectHandlers function, so this array contains proper objects (because of poor filledGaps creation, they are added twice - as GapWidgets and FilledGapWidgets)
@@ -46,6 +48,7 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 	
 	public TextView (TextModel module, boolean isPreview) {
 		this.module = module;
+		this.isPreview = isPreview;
 		createUI(isPreview);
 		mathJaxLoaded();
 	}
@@ -317,6 +320,9 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 
 	@Override
 	public void setHTML (String html) {
+		if (isPreview && module.hasSyntaxError()) {
+			html += "<div class=\"errorMessage\">" + DictionaryWrapper.get("text_parse_error") + "</div>";
+		}
 		super.setHTML(html);
 	}
 	

--- a/src/main/java/com/lorepo/icplayer/public/theme/player.css
+++ b/src/main/java/com/lorepo/icplayer/public/theme/player.css
@@ -670,7 +670,15 @@ hr, table, fieldset {
 	background-color: orange;
 	cursor: pointer;
 }
-
+/**
+ * Text
+ */
+ .ic_text .errorMessage{
+ 	padding: 1em;
+ 	font-size: 12px;
+ 	color: red;
+ } 
+ 
 /**
  * Source image
  */

--- a/src/test/java/com/lorepo/icplayer/client/module/text/GWTTextModelTestCase.java
+++ b/src/test/java/com/lorepo/icplayer/client/module/text/GWTTextModelTestCase.java
@@ -170,7 +170,7 @@ public class GWTTextModelTestCase extends GwtTest {
 		
 		TextModel module = new TextModel();
 		module.load(element, "", PAGE_VERSION);
-		
+
 		String EXPECTED_STRING = "type=\"edit\" data-gap=\"editable\" size=\"6\" class=\"ic_gap\"";
 		int index = module.getParsedText().indexOf(EXPECTED_STRING);
 		assertTrue(index > 0);

--- a/src/test/java/com/lorepo/icplayer/client/module/text/GWTTextParserTestCase.java
+++ b/src/test/java/com/lorepo/icplayer/client/module/text/GWTTextParserTestCase.java
@@ -311,7 +311,8 @@ public class GWTTextParserTestCase extends GwtTest{
 		parser.setId("xcf");
 		ParserResult parsed = parser.parse(srcText);
 		
-		assertEquals("#ERROR#", parsed.parsedText);
+		assertEquals("{{1 {{1:7200}}", parsed.parsedText);
+		assertTrue(parsed.hasSyntaxError);
 	}
 
 	@Test


### PR DESCRIPTION
Poprawki związane z błędem w edytorze dropdown gapy - w wypadku przesunięcia pierwszej opcji na inną pozycję pozostawała ona "prawidłową" odpowiedzią nawet gdy "keep in order" nie było zaznaczone, co powodowało błąd i zastąpienie zawartości modułu komunikatem o błędzie. Zmodyfikowałem parser, żeby informacja o błędzie w składni gapy dropdown była przekazywana oddzielnie, a nie zastępowała tekstu modułu.