### PR TITLE
Fixed issue with value of newly added properties being overwritten #7294

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2019-07-26 Fixed issue with the values of newly added properties being overwritten
 2019-07-22 Removed the ability to download the video in editable window
 2019-07-19 Added supporting of only audio to Editable Window
 2019-07-15 Fixed problem with editable window with video on IE

--- a/src/main/java/com/lorepo/icplayer/client/module/addon/param/ListAddonParam.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/addon/param/ListAddonParam.java
@@ -256,7 +256,10 @@ public class ListAddonParam extends StringAddonParam{
 			template.add(param);
 			
 			for(AddonParamProvider provider : propertyProviders){
-				provider.addParam(param);
+				IAddonParam childParam = addonParamFactory.createAddonParam(getAddonModel(), child.getType());
+				childParam.setName(child.getName());
+				childParam.setDisplayName(child.getDisplayName());
+				provider.addParam(childParam);
 			}
 		}
 		


### PR DESCRIPTION
Porpawiłem błąd, gdzie w sytuacji gdy do dzieci property typu list było dodawane nowe property, to wartość ostatniego dziecka nadpisywała pozostałe. 

W celu przetestowania należy najpierw utworzyć lekcję z addonem Slideshow na innej wersji testowej, niż test-7294. Następnie należy otworzyć tą lekcję w edytorze na instancji test-7294. W celach testowych dodałem na niej property typu tekstowego o nazwie Image do dzieci property Texts. Należy otworzyć property Texts i sprawdzić, czy nowo utworzone property są zapisywane poprawnie, w szczególności czy po zamknięciu i ponownym otworzeniu property Texts żadne wartości nie zostały nadpisane.

Wersja testowa: https://test-7294-dot-mauthor-dev.appspot.com
Zgłoszenie: https://learneticsa.assembla.com/spaces/lorepo/tickets/realtime_cardwall?ticket=7294