### PR TITLE
Fixed getState breaking Swiffy Animation, re #7283

### DIFF
--- a/addons/SwiffyAnimation/src/presenter.js
+++ b/addons/SwiffyAnimation/src/presenter.js
@@ -109,6 +109,8 @@ function AddonSwiffyAnimation_create(){
             e.stopImmediatePropagation();
             e.stopPropagation();
         });
+
+        view.addEventListener('DOMNodeRemoved', presenter.destroy);
         //console.log('run');
     };
 
@@ -303,18 +305,6 @@ function AddonSwiffyAnimation_create(){
     };
 
     presenter.getState = function(){
-        //console.log("---getState!");
-        if(presenter.loaded === true){
-            presenter.loaded = false;
-            $(presenter.swiffyContainer).html("");
-            $(presenter.Animations).each(function(i, animation){
-                if(presenter.animsRunning[i] === true && typeof presenter.stage[i] !== 'undefined'){
-                    presenter.stage[i].destroy();
-                }
-            });
-            $(presenter.loadingIconImg).css('display','block');
-        }
-
         return JSON.stringify({
             'currentAnimationItem' : presenter.currentAnimationItem,
             'animsRunning' : presenter.animsRunning,
@@ -344,6 +334,18 @@ function AddonSwiffyAnimation_create(){
             }
         });
 
+    };
+
+    presenter.destroy = function() {
+        if(presenter.loaded === true){
+            presenter.loaded = false;
+            $(presenter.swiffyContainer).html("");
+            $(presenter.Animations).each(function(i, animation){
+                if(presenter.animsRunning[i] === true && typeof presenter.stage[i] !== 'undefined'){
+                    presenter.stage[i].destroy();
+                }
+            });
+        }
     };
 
     return presenter;

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2019-08-06 Fixed getState breaking Swiffy Animation addon
 2019-07-26 Fixed scrolling while dragging the Slider on mobile devices
 2019-07-26 Fixed issue with the values of newly added properties being overwritten
 2019-07-26 Fixed opacity in Editable Window module


### PR DESCRIPTION
Poprawiłem błąd, przez który wywołania getState na SwiffyAnimation w trakcie pracy na stronie ( a nie np. w momencie wyjścia z niej) powodowało, że addon przestawał działać poprawnie.