### PR TITLE
Fixed IWB Toolbar zoom not working correctly in iframe #7377

### DIFF
--- a/addons/IWB_Toolbar/src/presenter.js
+++ b/addons/IWB_Toolbar/src/presenter.js
@@ -2485,8 +2485,16 @@ function AddonIWB_Toolbar_create() {
             presenter.changeCursor('zoom-in');
         } else {
             presenter.$panel.hide();
+            var topWindowHeight = 0;
+            var iframeTopOffset = 0;
+            if (window.iframeSize) {
+                topWindowHeight = window.iframeSize.windowInnerHeight;
+                iframeTopOffset = window.iframeSize.offsetTop - window.iframeSize.frameOffset;
+            }
             zoom.to({
-                element: selectedModule
+                element: selectedModule,
+                topWindowHeight: topWindowHeight,
+                iframeTopOffset: iframeTopOffset
             });
             $(selectedModule).addClass('zoomed');
             presenter.changeCursor('zoom-out');

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2019-08-30 Fixed IWB Toolbar zoom working incorrectly in iframe
 2019-08-20 Added alt text support to text identification
 2019-08-12 Fixed problem with editable window with audio on IE, EDGE, FIREFOX
 2019-07-31 Blocked the download audio in Editable Window module


### PR DESCRIPTION
Opcja zoom w IWB Toolbar przybliżała do złej pozycji, jeśli lekcja znajdowała się wewnątrz iframe'a. Dodałem możliwość przekazania informacji na temat rzeczywistych wymiarów ekranu i pozycji scroll'a, oraz uwzględniłem przy zoom'owaniu.

Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/7377--i-manuel--problem-z-zoom-w-iwb-toolbar/details?comment=1650064051
Wersja testowa: http://test-7377-ma-dot-mcourser-dev.appspot.com/