### PR TITLE
Fixing isAttempted

### DIFF
--- a/addons/Fractions/src/presenter.js
+++ b/addons/Fractions/src/presenter.js
@@ -91,7 +91,7 @@ function AddonFractions_create(){
 
     presenter.isAttempted = function(){
         presenter.hideAnswers();
-        if(presenter.configuration.isAnswer) {
+        if(!presenter.configuration.isAnswer) {
             return true;
         }
         return Counter === (presenter.initialMarks)/2 ? false : true;


### PR DESCRIPTION
Warunek w isAttempted był napisany odwrotnie. 
Jeśli nie jest ćwiczeniem ma zawsze zwracać true, jeśli jest ćwiczeniem musi być inna odpowiedź niż początkowa aby było true.