### PR TITLE
Fixed Coloring issue when initial layout is not default, re #6564

### DIFF
--- a/addons/Coloring/src/presenter.js
+++ b/addons/Coloring/src/presenter.js
@@ -1089,7 +1089,9 @@ function AddonColoring_create(){
 
         var areasToFill = presenter.getAreasToFillFromSetState(upgradedState);
 
-        presenter.restoreColoringAtState(areasToFill, upgradedState)
+        if (upgradedState.colorsThatCanBeFilled) {
+            presenter.restoreColoringAtState(areasToFill, upgradedState)
+        }
     };
 
     presenter.restoreColoringAtState = function (filledAreasArray, state) {

--- a/addons/Coloring/src/presenter.js
+++ b/addons/Coloring/src/presenter.js
@@ -22,6 +22,9 @@ function AddonColoring_create(){
     presenter.lastEvent = null;
     presenter.imageHasBeenLoaded = false;
 
+    presenter.initialState = null;
+    presenter.isCanvasInitiated = false;
+
     presenter.AREA_TYPE = {
         NORMAL: 0,
         TRANSPARENT: 1,
@@ -400,6 +403,7 @@ function AddonColoring_create(){
 
                 presenter.recolorImage();
                 presenter.runEndedDeferred.resolve();
+                presenter.isCanvasInitiated = true;
             }
         });
     }
@@ -979,6 +983,10 @@ function AddonColoring_create(){
 
     presenter.getState = function(){
 
+        if (!presenter.isCanvasInitiated && presenter.initialState != null) {
+            return presenter.initialState;
+        }
+
         if (presenter.isShowAnswersActive) {
             presenter.hideAnswers();
         }
@@ -1067,6 +1075,10 @@ function AddonColoring_create(){
     };
 
     presenter.setState = function(state){
+        if (!presenter.isCanvasInitiated) {
+            presenter.initialState = state;
+        }
+
         if (ModelValidationUtils.isStringEmpty(state)) {
             return;
         }

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2019-09-30 Fix Coloring issue when the first layer is not default
 2019-09-05 Fix ImageViewerPublic model upgrade.
 2019-09-23 Added TTS support to Image Viewer
 2019-09-17 Added a new text property for controlling how gap size attribute is calculated


### PR DESCRIPTION
Jeżeli pierwszy layout był inny niż domyślny, stan Coloring był pobierany przed pełnym załadowaniem canvasa, co powodowało błędy.

Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/6564--support--semi-responsive--coloring-dzia%C5%82a-tylko-je%C5%9Bli-jako-pierwszy-zostani/details
Wersja testowa: https://test-6564-dot-mauthor-dev.appspot.com/present/5670382692466688