### PR TITLE
[TrueFalse] Disable hidding showAnswers on getState #7506

### DIFF
--- a/addons/TrueFalse/src/presenter.js
+++ b/addons/TrueFalse/src/presenter.js
@@ -495,15 +495,22 @@ function AddonTrueFalse_create() {
     };
 
     presenter.getState = function () {
-        if (presenter.isShowAnswersActive) {
-            presenter.hideAnswers();
-        }
-
-        return JSON.stringify({
-            selectedElements: getSelectedElements(),
+        function getStateBase(selectedElements) {
+            return {
+            selectedElements: selectedElements,
             isVisible: presenter.isVisible,
             isDisabled: presenter.isDisabled
-        });
+            }
+        }
+
+        var state = {};
+        if (presenter.isShowAnswersActive) {
+            state = getStateBase(presenter.currentState); // This is saved on ShowAnswers
+        } else {
+            state = getStateBase(getSelectedElements());
+        }
+
+        return JSON.stringify(state);
     };
 
     presenter.setState = function (state) {

--- a/addons/TrueFalse/test/StatesTests.js
+++ b/addons/TrueFalse/test/StatesTests.js
@@ -16,11 +16,12 @@ TestCase("Get and Set State Tests", {
 
     'test get state in active show answers mode' : function() {
         this.presenter.isShowAnswersActive = true;
-        this.presenter.currentState = '[false, true, false]';
+        this.presenter.currentState = [false, true, false];
 
         var state = this.presenter.getState();
 
-        assertEquals('{\"selectedElements\":[false,false,false]}', state);
+        assertEquals('{\"selectedElements\":[false,true,false]}', state);
+        assertEquals(true, this.presenter.isShowAnswersActive);
     },
 
     'test set state function sets data properly' : function() {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2019-10-16 TrueFalse is not hidding show answers during getState
 2019-10-14 Optimize drawing frames in Animation addon
 2019-10-11 Added isAttempted command to Table.
 2019-10-10 Added TTS support to Slider


### PR DESCRIPTION
There is no possibility to easily extract logic from state and view. In this case, I've fixed only getState.
