### PR TITLE
[Catch] Clear objects in onDestroy method, re #6923

### DIFF
--- a/addons/Catch/src/presenter.js
+++ b/addons/Catch/src/presenter.js
@@ -183,12 +183,17 @@ function AddonCatch_create() {
     };
 
     presenter.onDestroy = function () {
-        objects.forEach( function(value) {
-            value.obj.stop(true);
-            value.obj.remove();
-        });
+        presenter.clearCatchObjects(objects);
 
         objects = null;
+    };
+
+    presenter.clearCatchObjects = function (objects) {
+        objects.forEach( function(value) {
+            value.obj.stop();
+            value.obj.remove();
+            value.obj = null;
+        });
     };
 
     function makePlate () {

--- a/addons/Catch/src/presenter.js
+++ b/addons/Catch/src/presenter.js
@@ -182,6 +182,15 @@ function AddonCatch_create() {
         }
     };
 
+    presenter.onDestroy = function () {
+        objects.forEach( function(value) {
+            value.obj.stop(true);
+            value.obj.remove();
+        });
+
+        objects = null;
+    };
+
     function makePlate () {
         var plateImage = presenter.configuration.plateImage !== "" && presenter.configuration.plateImage !== undefined ? presenter.configuration.plateImage : getImageUrlFromResources('plate.png');
 
@@ -689,3 +698,7 @@ function AddonCatch_create() {
 
     return presenter;
 }
+
+AddonCatch_create.__supported_player_options__ = {
+    interfaceVersion: 2
+};

--- a/addons/Catch/test/OnDestroyTests.js
+++ b/addons/Catch/test/OnDestroyTests.js
@@ -1,0 +1,45 @@
+function createSpyObject() {
+    return {
+        stop: sinon.spy(),
+        remove: sinon.spy()
+    };
+}
+
+TestCase("[Catch] On destroy tests", {
+    setUp: function () {
+        this.presenter = AddonCatch_create();
+
+        this.spyObjects = [
+            createSpyObject(),
+            createSpyObject(),
+            createSpyObject()
+        ];
+
+        this.catchObjects = this.spyObjects.map(function (spy) {
+            return {
+                obj: spy
+            }
+        });
+    },
+
+    'test given some catch object when clearing objects then calls stop and remove methods on all objects' : function () {
+        this.presenter.clearCatchObjects(this.catchObjects);
+
+        this.spyObjects.forEach(function(spy) {
+            sinon.assert.calledOnce(spy.stop);
+            sinon.assert.calledOnce(spy.remove);
+        });
+    },
+
+    'test given presenter object when calling onDestroy then calls clearCatchObjects method' : function () {
+        var spy = sinon.stub(this.presenter, "clearCatchObjects");
+
+        this.presenter.onDestroy();
+
+        sinon.assert.calledOnce(spy);
+
+        spy.restore();
+    }
+
+
+});

--- a/addons/Slideshow/src/presenter.js
+++ b/addons/Slideshow/src/presenter.js
@@ -1879,11 +1879,6 @@ function AddonSlideshow_create() {
         deferredQueue: deferredSyncQueue
     };
 
-
-    AddonSlideshow_create.__supported_player_options__ = {
-        interfaceVersion: 2
-    };
-
     presenter.keyboardController = function(keycode, isShiftKeyDown, event) {
         event.preventDefault();
         presenter.shiftPressed = event.shiftKey;
@@ -2042,3 +2037,7 @@ function AddonSlideshow_create() {
 
     return presenter;
 }
+
+AddonSlideshow_create.__supported_player_options__ = {
+    interfaceVersion: 2
+};

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2019-10-28 Added clearing Catch addon objects on page change.
 2019-10-24 When table is not activity or does not have gaps, then return true in isAttempted
 2019-10-24 Fixed problem with animation and transparency.
 2019-10-23 Fixed error in destroy method in IWB Toolbar module


### PR DESCRIPTION
Because added animation objects weren't stopped and removed they were being played and sending events after page change.
Also __supported_player_options__ needs to be in outer scope of presenter, otherwise it doesn't work on first page change.