### PR TITLE
Added Count Errors property to Text Coloring, re #7013

### DIFF
--- a/addons/Text_Coloring/src/addon.xml
+++ b/addons/Text_Coloring/src/addon.xml
@@ -13,5 +13,6 @@
 		<property name="showSetEraserModeButton" displayName="Show set eraser mode button" nameLabel="Text_Coloring_property_show_set_eraser_mode_button" type="boolean" />
 		<property name="eraserButtonText" displayName="Eraser button text" nameLabel="Text_Coloring_property_eraser_button_text" type="string" isLocalized="true" />
 		<property name='Mode' nameLabel="Text_Selection_property_mode" type='{All selectable, Mark phrases to select}'/>
+		<property name="countErrors" displayName="Count Errors" nameLabel="Text_Coloring_property_count_errors" type="boolean" />
 	</model>
 </addon>

--- a/addons/Text_Coloring/src/presenter.js
+++ b/addons/Text_Coloring/src/presenter.js
@@ -634,6 +634,7 @@ function AddonText_Coloring_create() {
 
     presenter.upgradeModel = function(model) {
         var upgradedModel = upgradeModelAddModeProperty(model);
+        upgradedModel = upgradeModelAddCountErrorsProperty(upgradedModel);
         return upgradedModel;
     };
 
@@ -643,6 +644,17 @@ function AddonText_Coloring_create() {
 
         if(!upgradedModel['Mode']){
             upgradedModel['Mode'] = presenter.MODE.DEFAULT;
+        }
+
+        return upgradedModel;
+    }
+
+    function upgradeModelAddCountErrorsProperty(model) {
+        var upgradedModel = {};
+        $.extend(true, upgradedModel, model);
+
+        if(!upgradedModel['countErrors']) {
+            upgradedModel['countErrors'] = false;
         }
 
         return upgradedModel;
@@ -674,7 +686,8 @@ function AddonText_Coloring_create() {
             hideColorsButtons: ModelValidationUtils.validateBoolean(model.hideColorsButtons),
             eraserButtonText: presenter.parseEraserButtonText(model.eraserButtonText),
             isVisible: ModelValidationUtils.validateBoolean(model['Is Visible']),
-            mode: mode
+            mode: mode,
+            countErrors: ModelValidationUtils.validateBoolean(model.countErrors)
         };
     };
 
@@ -1340,9 +1353,14 @@ function AddonText_Coloring_create() {
     };
 
     presenter.isAllOK = function () {
-        return presenter.configuration.filteredTokens.filter(filterSelectablesTokens).every(function (token) {
-            return presenter.getScoreForWordMarking(token.index, token.selectionColorID);
-        });
+        if (presenter.configuration.countErrors) {
+            return presenter.getMaxScore() === presenter.getScore() - presenter.getErrorCount();
+        } else {
+            return presenter.configuration.filteredTokens.filter(filterSelectablesTokens).every(function (token) {
+                return presenter.getScoreForWordMarking(token.index, token.selectionColorID);
+            });
+        }
+
     };
 
     presenter.addCorrectClass = function (tokenIndex) {

--- a/addons/Text_Coloring/test/IsAllOKTest.js
+++ b/addons/Text_Coloring/test/IsAllOKTest.js
@@ -1,0 +1,56 @@
+TestCase("[TextColoring] AllOk Event", {
+    setUp: function () {
+        this.presenter = AddonText_Coloring_create();
+        this.presenter.configuration = {
+            countErrors: true
+        };
+
+        this.stubs = {
+            getMaxScoreStub: sinon.stub(this.presenter, 'getMaxScore'),
+            getScoreStub: sinon.stub(this.presenter, 'getScore'),
+            getErrorCountStub: sinon.stub(this.presenter, 'getErrorCount')
+        };
+
+        this.$element = $('<div></div>');
+    },
+
+    'test given countErrors==true, Score==maxScore and errors==0, when calling isAllOk, then return true': function () {
+        this.stubs.getMaxScoreStub.returns(3);
+        this.stubs.getScoreStub.returns(3);
+        this.stubs.getErrorCountStub.returns(0);
+
+        var result = this.presenter.isAllOK();
+
+        assertTrue(result);
+    },
+
+    'test given countErrors==true, Score==maxScore and errors!=0, when calling isAllOk, then return false': function () {
+        this.stubs.getMaxScoreStub.returns(3);
+        this.stubs.getScoreStub.returns(3);
+        this.stubs.getErrorCountStub.returns(1);
+
+        var result = this.presenter.isAllOK();
+
+        assertFalse(result);
+    },
+
+    'test given countErrors==true, Score!=maxScore and errors!=0, when calling isAllOk, then return false': function () {
+        this.stubs.getMaxScoreStub.returns(3);
+        this.stubs.getScoreStub.returns(2);
+        this.stubs.getErrorCountStub.returns(1);
+
+        var result = this.presenter.isAllOK();
+
+        assertFalse(result);
+    },
+
+    'test given countErrors==true, Score!=maxScore and errors==0, when calling isAllOk, then return false': function () {
+        this.stubs.getMaxScoreStub.returns(3);
+        this.stubs.getScoreStub.returns(2);
+        this.stubs.getErrorCountStub.returns(0);
+
+        var result = this.presenter.isAllOK();
+
+        assertFalse(result);
+    }
+});

--- a/addons/Text_Coloring/test/ModelValidationTests.js
+++ b/addons/Text_Coloring/test/ModelValidationTests.js
@@ -262,7 +262,8 @@ TestCase("[Text_Coloring] Model Validation flow", {
             showSetEraserButtonMode: false,
             hideColorsButtons: false,
             eraserButtonText: eraserButtonText,
-            mode: "MARK_PHRASES"
+            mode: "MARK_PHRASES",
+            countErrors: false
 
         };
 
@@ -306,5 +307,12 @@ TestCase("[Text_Coloring] parse Buttons position", {
         assertEquals("left", this.presenter.parseButtonsPosition("left"));
         assertEquals("bottom", this.presenter.parseButtonsPosition("bottom"));
         assertEquals("right", this.presenter.parseButtonsPosition("right"));
+    },
+
+    'test given model without countErrors when upgrading model should add countErrors field with def value': function () {
+        var upgradedModel = this.presenter.upgradeModel({});
+
+        assertTrue(upgradedModel.countErrors != undefined);
+        assertFalse(upgradedModel.countErrors);
     }
 });

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2019-10-28 Added Count Errors property to Text Coloring
 2019-10-24 When table is not activity or does not have gaps, then return true in isAttempted
 2019-10-24 Fixed problem with animation and transparency.
 2019-10-23 Fixed error in destroy method in IWB Toolbar module

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/bl/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/bl/dictionary.js
@@ -1363,6 +1363,7 @@ var ice_dictionary_bl = {
 	"Text_Coloring_property_hide_color_buttons": "Скрий бутони за цвят",
 	"Text_Coloring_property_show_set_eraser_mode_button": "Покажи бутон с гумичка",
 	"Text_Coloring_property_eraser_button_text": "Текст на бутона с гумичка",
+	"Text_Coloring_property_count_errors": "Count Errors",
 	"Text_Selection_info": "Позволява да се маркират определени части текст. Работи в два режима – 'Маркиране на определени изрази', където може да въведете верни и грешни отговори и 'Маркиране на всички', където всичко изрази могат да се маркират, а вие трябва да отбележите само верните отговори.",
 	"Text_Selection_name": "Маркиране на текст",
 	"Text_Selection_property_mode": "Режим",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/com/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/com/dictionary.js
@@ -1364,6 +1364,7 @@ var ice_dictionary_en = {
 	"Text_Coloring_property_hide_color_buttons": "Hide Color Buttons",
 	"Text_Coloring_property_show_set_eraser_mode_button": "Show set eraser mode button",
 	"Text_Coloring_property_eraser_button_text": "Eraser button text",
+	"Text_Coloring_property_count_errors": "Count Errors",
 	"Text_Selection_info": "Allows to select dpecific parts of text. It works in two modes – 'Mark phrases to select', where you can mark wrong and correct answers or 'All selectable', where all phrases are selectable and you can mark only the correct answers.",
 	"Text_Selection_name": "Text Selection",
 	"Text_Selection_property_mode": "Mode",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/fr/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/fr/dictionary.js
@@ -1364,6 +1364,7 @@ var ice_dictionary_fr = {
     "Text_Coloring_property_hide_color_buttons": "Cacher Colorier les boutons",
     "Text_Coloring_property_show_set_eraser_mode_button": "Afficher le bouton du mode effacer",
     "Text_Coloring_property_eraser_button_text": "Texte du bouton effacer",
+	"Text_Coloring_property_count_errors": "Count Errors",
     "Text_Selection_info": "Permet de sélectionner des parties spécifiques du texte. Il fonctionne en deux modes – le mode 'Cliquer sur les phrases à sélectionner', où vous pouvez cliquer soit sur les mauvaises réponses, soit sur les bonnes, ou le mode 'Tout sélectionner', où toutes les phrases sont sélectionnables mais où vous ne cliquerez que sur les bonnes réponses.",
     "Text_Selection_name": "Sélection de texte",
     "Text_Selection_property_mode": "Mode",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/mx/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/mx/dictionary.js
@@ -1364,6 +1364,7 @@ var ice_dictionary_mx = {
 	"Text_Coloring_property_hide_color_buttons": "Ocultar los botones",
 	"Text_Coloring_property_show_set_eraser_mode_button": "Mostrar el botón de borrador",
 	"Text_Coloring_property_eraser_button_text": "Etiqueta para botón de borrador",
+	"Text_Coloring_property_count_errors": "Count Errors",
 	"Text_Selection_info": "Permite seleccionar partes específicas del texto. Funciona en dos modos: 1. 'Marcar frases para seleccionar', donde se pueden definir las respuestas correctas y incorrectas, 2. 'Todo seleccionable', donde todas las palabras están listas para seleccionar pero hay que encontrar las orrectas.",
 	"Text_Selection_name": "Selección de Texto",
 	"Text_Selection_property_mode": "Modo",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/pl/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/pl/dictionary.js
@@ -1363,6 +1363,7 @@ var ice_dictionary_pl = {
 	"Text_Coloring_property_hide_color_buttons": "Ukryj przyciski z kolorami",
 	"Text_Coloring_property_show_set_eraser_mode_button": "Pokaż przycisk ustawienia trybu gumki",
 	"Text_Coloring_property_eraser_button_text": "Tekst przycisku gumki",
+	"Text_Coloring_property_count_errors": "Count Errors",
 	"Text_Selection_info" : "Pozwala na zaznaczanie wybranych partii tekstu; działa w dwóch trybach – „Mark phrases to select”, w którym można zdefiniować poprawne i błędne odpowiedzi oraz „All selectable”, gdzie można określić tylko poprawne odpowiedzi, a wszystkie wyrażenia są gotowe do zaznaczenia.",
 	"Text_Selection_name" : "Zaznaczanie tekstu",
 	"Text_Selection_property_mode" : "Tryb",


### PR DESCRIPTION
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/7013--support--event-isallok-w-text-coloring-nie-bierze-pod-uwag%C4%99-b%C5%82%C4%99d/details
Wersja testowa: https://test-7013-dot-mauthor-dev.appspot.com/embed/5359658183163904

Dodałem property Count Errors do addonu Text Coloring (boolean, domyślnie false). Jeżeli jest ustawione na true, obecność jakichkolwiek błędów zablokuje wysłanie eventu AllOk. Jeżeli jes ustawione na false, addon będzie działać tak jak dotychczas.

