### PR TITLE
Alt text in gaps, re #7555

### DIFF
--- a/src/main/java/com/lorepo/icplayer/client/model/alternativeText/AlternativeTextService.java
+++ b/src/main/java/com/lorepo/icplayer/client/model/alternativeText/AlternativeTextService.java
@@ -124,7 +124,7 @@ public class AlternativeTextService {
             }
         }
 
-        // alt text was only at the begining and there is more text which needs to be added to the token list
+        // alt text was only at the beginning and there is more text which needs to be added to the token list
         if (input.length() > 0) {
             altTokens.add(new Token(input));
         }

--- a/src/main/java/com/lorepo/icplayer/client/model/alternativeText/AlternativeTextTemplates.java
+++ b/src/main/java/com/lorepo/icplayer/client/model/alternativeText/AlternativeTextTemplates.java
@@ -1,0 +1,17 @@
+package com.lorepo.icplayer.client.model.alternativeText;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.safehtml.client.SafeHtmlTemplates;
+import com.google.gwt.safehtml.shared.SafeHtml;
+
+public class AlternativeTextTemplates {
+    public interface AltTextTemplate extends SafeHtmlTemplates {
+        @Template("\\altEscaped{0}&altTextSeperator&{1}&altTextEnd&")
+        SafeHtml altTextEscaped(String visible, String readable);
+
+        @Template("[lang {0}]")
+        SafeHtml langTag(String lang);
+    }
+
+    public static final AltTextTemplate TEMPLATES = GWT.create(AltTextTemplate.class);
+}

--- a/src/main/java/com/lorepo/icplayer/client/module/text/DraggableGapWidget.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/DraggableGapWidget.java
@@ -225,7 +225,7 @@ public class DraggableGapWidget extends HTML implements TextElementDisplay, AltT
 			answerText = TextParser.removeHtmlFormatting(visibleText);
 			droppedElementHelper = getElement(visibleText);
 			setStylePrimaryName(FILLED_GAP_STYLE);
-			if(droppedElementHelper.length() != 0 && !isShowAnswersMode){
+			if (!droppedElementHelper.isEmpty() && !isShowAnswersMode){
 				JavaScriptUtils.makeDroppedDraggableText(this.getElement(), getAsJavaScript(), droppedElementHelper);
 			}
 		}

--- a/src/main/java/com/lorepo/icplayer/client/module/text/GapInfo.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/GapInfo.java
@@ -35,7 +35,6 @@ public class GapInfo implements IGapCommonUtilsProvider {
 		this.langTag = langTag;
 	}
 
-
 	public void addAnswer(String answer) {
 		answer = StringUtils.unescapeXML(answer);
 		answer = answer.replaceAll("&nbsp;", " ");

--- a/src/main/java/com/lorepo/icplayer/client/module/text/GapInfo.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/GapInfo.java
@@ -37,9 +37,11 @@ public class GapInfo implements IGapCommonUtilsProvider {
 	}
 
 	public void addAnswer(String answer) {
+		boolean matchAllVisbileText = true;
 		answer = StringUtils.unescapeXML(answer);
 		answer = answer.replaceAll("&nbsp;", " ");
-		answer = TextParser.unescapeAltText(answer);
+		// this is needed for showing visible text when show answer is called on gap
+		answer = AlternativeTextService.unescapeAltText(answer, matchAllVisbileText);
 		answers.add(answer);
 		if(isIgnorePunctuation) { answer = removePunctuation(answer); }
 		checkAnswers.add(isCaseSensitive ? answer : answer.toLowerCase());

--- a/src/main/java/com/lorepo/icplayer/client/module/text/GapInfo.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/GapInfo.java
@@ -5,6 +5,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import com.lorepo.icf.utils.StringUtils;
+import com.lorepo.icplayer.client.model.alternativeText.AlternativeTextService;
 
 public class GapInfo implements IGapCommonUtilsProvider {
 
@@ -38,7 +39,7 @@ public class GapInfo implements IGapCommonUtilsProvider {
 	public void addAnswer(String answer) {
 		answer = StringUtils.unescapeXML(answer);
 		answer = answer.replaceAll("&nbsp;", " ");
-		
+		answer = TextParser.unescapeAltText(answer);
 		answers.add(answer);
 		if(isIgnorePunctuation) { answer = removePunctuation(answer); }
 		checkAnswers.add(isCaseSensitive ? answer : answer.toLowerCase());
@@ -84,16 +85,16 @@ public class GapInfo implements IGapCommonUtilsProvider {
 	}
 
 	public boolean isCorrect(String text) {
-
 		boolean correct = false;
-		if(!isCaseSensitive){
+		if (!isCaseSensitive) {
 			text = text.toLowerCase();
 		}
-		if(isIgnorePunctuation){
+		if (isIgnorePunctuation) {
 			text = removePunctuation(text);
 		}
-		for(String answer : checkAnswers){
-			if(answer.compareTo(text) == 0){
+		for (String answer : checkAnswers) {
+			String parsedAnswer = AlternativeTextService.getVisibleText(answer);
+			if (parsedAnswer.compareTo(text) == 0) {
 				correct = true;
 				break;
 			}

--- a/src/main/java/com/lorepo/icplayer/client/module/text/GapInfo.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/GapInfo.java
@@ -94,6 +94,7 @@ public class GapInfo implements IGapCommonUtilsProvider {
 		if (isIgnorePunctuation) {
 			text = removePunctuation(text);
 		}
+		text = AlternativeTextService.getVisibleText(text);
 		for (String answer : checkAnswers) {
 			String parsedAnswer = AlternativeTextService.getVisibleText(answer);
 			if (parsedAnswer.compareTo(text) == 0) {

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextParser.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextParser.java
@@ -425,14 +425,6 @@ public class TextParser {
 		}
 		return replaceText;
 	}
-
-	private void addAnswersToFilledDraggableGapInfo(GapInfo gi, String answer) {
-		String answersWithEscapedAltText = TextParser.escapeAltText(answer);
-		String[] answers = answersWithEscapedAltText.split("\\|");
-		for (String singleAnswer : answers) {
-			gi.addAnswer(singleAnswer);
-		}
-	}
 	
 	private String matchDraggableGap(String expression, Map<String,String> gapOptions) {
 		String langTag = getLangTagForGap(gapOptions);
@@ -456,59 +448,6 @@ public class TextParser {
 		}
 
 		return replaceText;
-	}
-
-	private String getSpanElementCode(String id, String innerHTML, String[] classes) {
-		DomElementManipulator spanElement = new DomElementManipulator("span");
-		spanElement.setHTMLAttribute("id", id);
-		spanElement.setInnerHTMLText(innerHTML);
-		for (String className : classes) {
-			spanElement.addClass(className);
-		}
-
-		return spanElement.getHTMLCode();
-	}
-
-	private String getSpanElementCodeForDraggableFilledGap(String id, String placeholder) {
-		String[] classes = {
-			"ic_draggableGapEmpty",
-			"ic_filled_gap"
-		};
-
-		return getSpanElementCode(id, placeholder, classes);
-	}
-
-	private String getSpanElementCodeForDraggableGap(String id) {
-		String[] classes = {
-			"ic_draggableGapEmpty"
-		};
-		String innerHTML = DomElementManipulator.getFromHTMLCodeUnicode("&#160");
-
-		return getSpanElementCode(id, innerHTML, classes);
-	}
-
-	private void addAnswersToDraggableGapInfo(GapInfo gi, String answerValue) {
-		String answersWithEscapedAltText = TextParser.escapeAltText(answerValue);
-
-		String[] answers = answersWithEscapedAltText.split("\\|"); // answers are divided by | sign
-		String answerToken = null;
-
-		for (String singleAnswer : answers) {
-			if (answerToken != null) {
-				answerToken += "|" + singleAnswer;
-			} else {
-				answerToken = singleAnswer;
-			}
-			// check if answer contains math expression
-			if (answerToken.indexOf("\\(") < 0 || answerToken.indexOf("\\)") > 0) {
-				gi.addAnswer(answerToken);
-				answerToken = null;
-			}
-		}
-
-		if (answerToken != null) {
-			gi.addAnswer(answerToken);
-		}
 	}
 
 	private String getLangTagForGap(Map<String,String> gapOptions) {
@@ -1045,7 +984,7 @@ public class TextParser {
 
 		return buttonElement.getHTMLCode() + audioElement.getHTMLCode();
 	}
-	
+
 	public String parseAltText(String srcText) {
 		return AlternativeTextService.getAltTextAsHtml(srcText);
 	}
@@ -1059,18 +998,18 @@ public class TextParser {
 		String parsedText = srcText.replaceAll("\\\\altEscaped([^\\|\\{\\}]*?)&altTextSeperator&([^\\|\\{\\}]*?)&altTextEnd&", "\\\\alt\\{$1\\|$2\\}");
 		return parsedText;
 	}
-	
+
 	private String getReadableAltText(String srcText){
 		String parsedText =  srcText.replaceAll("\\\\alt\\{.*?\\|(.*?)\\}(\\[[a-zA-Z0-9_\\- ]*?\\])*", "$1");
 		return parsedText;
 	}
-	
+
 	public Map<String,String> getGapOptions(String expression) {
 		final String pattern = 	"^\\[[a-zA-Z0-9_\\- ]*?\\]";
 		Map<String,String> result = new HashMap<String,String>();
 		RegExp regExp = RegExp.compile(pattern);
 		MatchResult matchResult;
-		
+
 		while ((matchResult = regExp.exec(expression)) != null) {
 			if (matchResult.getGroupCount() <= 0) {
 				break;
@@ -1086,12 +1025,12 @@ public class TextParser {
 		}
 		return result;
 	};
-	
+
 	public static String removeGapOptions(String expression) {
 		final String pattern = 	"^\\[[a-zA-Z0-9_\\- ]*?\\]";
 		RegExp regExp = RegExp.compile(pattern);
 		MatchResult matchResult;
-		
+
 		while ((matchResult = regExp.exec(expression)) != null) {
 			if (matchResult.getGroupCount() <= 0) {
 				break;
@@ -1107,7 +1046,7 @@ public class TextParser {
 		}
 		return expression;
 	};
-	
+
 	public void skipGaps() {
 		skipGaps = true;
 	}
@@ -1115,8 +1054,8 @@ public class TextParser {
 	public void setGapWidth(int gapWidth) {
 		this.gapWidth = gapWidth;
 	}
-	
-	
+
+
 	public void setGapMaxLength(int gapMaxLength) {
 		this.gapMaxLength = gapMaxLength;
 	}
@@ -1124,14 +1063,75 @@ public class TextParser {
 	public void setUseEscapeCharacterInGap(boolean isUsing) {
 		this.useEscapeCharacterInGap = isUsing;
 	}
-	
+
 	public List<String> getGapsOrder () {
 		return this.gapsOrder;
 	}
-	
+
 	public static String removeHtmlFormatting( String html) {
 		Element el = (new HTML(html)).getElement();
 		return el.getInnerText();
+	}
+
+	private String getSpanElementCode(String id, String innerHTML, String[] classes) {
+		DomElementManipulator spanElement = new DomElementManipulator("span");
+		spanElement.setHTMLAttribute("id", id);
+		spanElement.setInnerHTMLText(innerHTML);
+		for (String className : classes) {
+			spanElement.addClass(className);
+		}
+
+		return spanElement.getHTMLCode();
+	}
+
+	private String getSpanElementCodeForDraggableFilledGap(String id, String placeholder) {
+		String[] classes = {
+				"ic_draggableGapEmpty",
+				"ic_filled_gap",
+		};
+
+		return getSpanElementCode(id, placeholder, classes);
+	}
+
+	private String getSpanElementCodeForDraggableGap(String id) {
+		String[] classes = {
+				"ic_draggableGapEmpty",
+		};
+		String innerHTML = DomElementManipulator.getFromHTMLCodeUnicode("&#160");
+
+		return getSpanElementCode(id, innerHTML, classes);
+	}
+
+	private void addAnswersToDraggableGapInfo(GapInfo gi, String answerValue) {
+		String answersWithEscapedAltText = TextParser.escapeAltText(answerValue);
+
+		String[] answers = answersWithEscapedAltText.split("\\|"); // answers are divided by | sign
+		String answerToken = null;
+
+		for (String singleAnswer : answers) {
+			if (answerToken != null) {
+				answerToken += "|" + singleAnswer;
+			} else {
+				answerToken = singleAnswer;
+			}
+			// check if answer contains math expression
+			if (answerToken.indexOf("\\(") < 0 || answerToken.indexOf("\\)") > 0) {
+				gi.addAnswer(answerToken);
+				answerToken = null;
+			}
+		}
+
+		if (answerToken != null) {
+			gi.addAnswer(answerToken);
+		}
+	}
+
+	private void addAnswersToFilledDraggableGapInfo(GapInfo gi, String answer) {
+		String answersWithEscapedAltText = TextParser.escapeAltText(answer);
+		String[] answers = answersWithEscapedAltText.split("\\|");
+		for (String singleAnswer : answers) {
+			gi.addAnswer(singleAnswer);
+		}
 	}
 
 }

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextParser.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextParser.java
@@ -99,9 +99,9 @@ public class TextParser {
 					parserResult.parsedText = parseGaps(srcText);
 					parserResult.parsedText = parseAudio(parserResult.parsedText);
 					if (!useMathGaps) {
-						parserResult.parsedText = escapeAltText(parserResult.parsedText);
+						parserResult.parsedText = AlternativeTextService.escapeAltText(parserResult.parsedText);
 						parserResult.parsedText = parseOldSyntax(parserResult.parsedText);
-						parserResult.parsedText = unescapeAltText(parserResult.parsedText);
+						parserResult.parsedText = AlternativeTextService.unescapeAltText(parserResult.parsedText);
 					}
 					parserResult.parsedText = parseExternalLinks(parserResult.parsedText);
 					parserResult.parsedText = parseLinks(parserResult.parsedText);
@@ -310,7 +310,7 @@ public class TextParser {
 			return "";
 		}
 		String gapString = "";
-		for(String key : gapOptions.keySet()){
+		for (String key : gapOptions.keySet()) {
 			gapString+="["+key+" "+gapOptions.get(key)+"]";
 		}
 		return gapString;
@@ -506,8 +506,8 @@ public class TextParser {
 				String value = expression.substring(0, index).trim();
 				String answerValues = StringUtils.removeNewlines(expression.substring(index + 1));
 				String[] answers = answerValues.split("\\|");
-				for(int i=0;i<answers.length;i++){
-					answers[i]=unescapeAltText(answers[i]);
+				for (int i = 0; i < answers.length; i++) {
+					answers[i]= AlternativeTextService.unescapeAltText(answers[i]);
 				}
 				if (answers.length > 1) {
 
@@ -584,8 +584,8 @@ public class TextParser {
 		int index = expression.indexOf(":");
 		if (index > 0) {
 			String[] answers = expression.split("\\|");
-			for(int i=0;i<answers.length;i++){
-				answers[i]=unescapeAltText(answers[i]);
+			for (int i = 0; i < answers.length; i++) {
+				answers[i]=  AlternativeTextService.unescapeAltText(answers[i]);
 			}
 			
 			if (answers.length > 1) {
@@ -989,17 +989,7 @@ public class TextParser {
 		return AlternativeTextService.getAltTextAsHtml(srcText);
 	}
 
-	public static String escapeAltText(String srcText){
-		String parsedText = srcText.replaceAll("\\\\alt\\{([^\\|\\{\\}]*?)\\|([^\\|\\{\\}]*?)\\}", "\\\\altEscaped$1&altTextSeperator&$2&altTextEnd&");
-		return parsedText;
-	}
-
-	public static String unescapeAltText(String srcText){
-		String parsedText = srcText.replaceAll("\\\\altEscaped([^\\|\\{\\}]*?)&altTextSeperator&([^\\|\\{\\}]*?)&altTextEnd&", "\\\\alt\\{$1\\|$2\\}");
-		return parsedText;
-	}
-
-	private String getReadableAltText(String srcText){
+	private String getReadableAltText(String srcText) {
 		String parsedText =  srcText.replaceAll("\\\\alt\\{.*?\\|(.*?)\\}(\\[[a-zA-Z0-9_\\- ]*?\\])*", "$1");
 		return parsedText;
 	}
@@ -1103,7 +1093,7 @@ public class TextParser {
 	}
 
 	private void addAnswersToDraggableGapInfo(GapInfo gi, String answerValue) {
-		String answersWithEscapedAltText = TextParser.escapeAltText(answerValue);
+		String answersWithEscapedAltText = AlternativeTextService.escapeAltTextWithAllVisibleText(answerValue);
 
 		String[] answers = answersWithEscapedAltText.split("\\|"); // answers are divided by | sign
 		String answerToken = null;
@@ -1127,7 +1117,7 @@ public class TextParser {
 	}
 
 	private void addAnswersToFilledDraggableGapInfo(GapInfo gi, String answer) {
-		String answersWithEscapedAltText = TextParser.escapeAltText(answer);
+		String answersWithEscapedAltText = AlternativeTextService.escapeAltText(answer);
 		String[] answers = answersWithEscapedAltText.split("\\|");
 		for (String singleAnswer : answers) {
 			gi.addAnswer(singleAnswer);

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
@@ -13,7 +13,6 @@ import com.lorepo.icf.scripting.IType;
 import com.lorepo.icf.utils.JSONUtils;
 import com.lorepo.icf.utils.JavaScriptUtils;
 import com.lorepo.icf.utils.StringUtils;
-import com.lorepo.icplayer.client.model.alternativeText.AlternativeTextService;
 import com.lorepo.icplayer.client.module.IEnterable;
 import com.lorepo.icplayer.client.module.IWCAG;
 import com.lorepo.icplayer.client.module.IWCAGPresenter;
@@ -566,11 +565,11 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
 	}
 
      private String getElementText(GapInfo gap) {
-		String t =  getElementText(gap.getId());
-		if(t.isEmpty() && !gap.getPlaceHolder().isEmpty()) {
-			t = gap.getPlaceHolder();
+		String userAnswer =  getElementText(gap.getId());
+		if (userAnswer.isEmpty() && !gap.getPlaceHolder().isEmpty()) {
+			userAnswer = gap.getPlaceHolder();
 		}
-		return t;
+		return userAnswer;
 	}
 	
 	@Override
@@ -1015,7 +1014,7 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
 
 		GapInfo gap = getGapInfoById(itemID);
 		String enteredValue = getElementText(gap);
-		if (enteredValue == gap.getPlaceHolder() && !gap.isCorrect(gap.getPlaceHolder())) {
+		if (enteredValue.equals(gap.getPlaceHolder()) && !gap.isCorrect(gap.getPlaceHolder())) {
 			enteredValue = "";
 		}
 		if (gap.isCorrect(enteredValue)) {

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
@@ -13,6 +13,7 @@ import com.lorepo.icf.scripting.IType;
 import com.lorepo.icf.utils.JSONUtils;
 import com.lorepo.icf.utils.JavaScriptUtils;
 import com.lorepo.icf.utils.StringUtils;
+import com.lorepo.icplayer.client.model.alternativeText.AlternativeTextService;
 import com.lorepo.icplayer.client.module.IEnterable;
 import com.lorepo.icplayer.client.module.IWCAG;
 import com.lorepo.icplayer.client.module.IWCAGPresenter;
@@ -210,7 +211,8 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
 
 			// show 1st answer
 			Iterator<String> answers = gi.getAnswers();
-			gapsViewsElements.get(gi.getId()).setText(answers.hasNext() ? answers.next() : "");
+			String answer = answers.hasNext() ? answers.next() : "";
+			gapsViewsElements.get(gi.getId()).setText(answer);
 		}
 
 		for (InlineChoiceInfo choice : module.getChoiceInfos()) {

--- a/src/main/java/com/lorepo/icplayer/client/module/text/WCAGUtils.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/WCAGUtils.java
@@ -7,8 +7,6 @@ import com.google.gwt.user.client.ui.HTML;
 import com.lorepo.icf.utils.TextToSpeechVoice;
 import com.lorepo.icplayer.client.module.text.TextPresenter.TextElementDisplay;
 
-import javax.xml.soap.Text;
-
 
 public class WCAGUtils {
 	final static String GAP_START = "\\gap{";

--- a/src/main/java/com/lorepo/icplayer/client/module/text/WCAGUtils.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/WCAGUtils.java
@@ -7,6 +7,8 @@ import com.google.gwt.user.client.ui.HTML;
 import com.lorepo.icf.utils.TextToSpeechVoice;
 import com.lorepo.icplayer.client.module.text.TextPresenter.TextElementDisplay;
 
+import javax.xml.soap.Text;
+
 
 public class WCAGUtils {
 	final static String GAP_START = "\\gap{";
@@ -78,7 +80,7 @@ public class WCAGUtils {
 	
 	// TODO change to ENUM
 	private static TextToSpeechVoice getElementStatus (TextElementDisplay element, TextModel model) {
-		if (!element.isWorkingMode()) {
+		if (element != null && !element.isWorkingMode()) {
 			if (element.getGapState() == 1) {
 				return TextToSpeechVoice.create(model.getSpeechTextItem(TextModel.CORRECT_INDEX));
 			}
@@ -159,8 +161,9 @@ public class WCAGUtils {
 			final TextElementDisplay element = !isClosestBreak ? getElement(textElements, gapNumber - 1) : null;
 			String langTag = element != null && element.getLangTag() != null ? element.getLangTag() : lang;
 
-			final String elementContent = element != null ? getElementTextElementContent(element) : null;
+			final String elementContent = element != null ? getElementTextElementContent(element) : "";
 			final List<TextToSpeechVoice> content = new ArrayList<TextToSpeechVoice>();
+
 			if (element instanceof AltTextGap) {
 				content.addAll(((AltTextGap) element).getReadableText());
 			} else {
@@ -181,8 +184,8 @@ public class WCAGUtils {
 				result.add(TextToSpeechVoice.create(model.getSpeechTextItem(TextModel.GAP_INDEX) + " " + gapNumber++));
 				result.addAll(content);
 				result.add(getElementStatus(element, model));
-				
-				final int endGapIndex = text.indexOf(FILLED_GAP_END, filledGapIndex) + FILLED_GAP_END.length();
+
+				final int endGapIndex = WCAGUtils.getGapEndIndex(text, filledGapIndex) + FILLED_GAP_END.length();
 				text = text.substring(endGapIndex);
 			}
 			if (isClosestDropdown) {

--- a/src/test/java/com/lorepo/icplayer/client/model/AltText/AltTextParsingTestCase.java
+++ b/src/test/java/com/lorepo/icplayer/client/model/AltText/AltTextParsingTestCase.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 import static junit.framework.Assert.assertEquals;
 
-public class AltTextServiceTestCase {
+public class AltTextParsingTestCase {
 
     @Test
     public void givenTextInInputWhenTokensThenReturnsParsedTokens() {

--- a/src/test/java/com/lorepo/icplayer/client/model/AltText/GWTAltTextEscapingTestCase.java
+++ b/src/test/java/com/lorepo/icplayer/client/model/AltText/GWTAltTextEscapingTestCase.java
@@ -1,0 +1,131 @@
+package com.lorepo.icplayer.client.model.AltText;
+
+import com.googlecode.gwt.test.GwtModule;
+import com.googlecode.gwt.test.GwtTest;
+import com.lorepo.icplayer.client.model.alternativeText.AlternativeTextService;
+import org.junit.Test;
+
+
+import static junit.framework.Assert.assertEquals;
+
+@GwtModule("com.lorepo.icplayer.Icplayer")
+public class GWTAltTextEscapingTestCase extends GwtTest {
+    @Test
+    public void givenTextWithoutAltTextWhenEscapingBasicAltTextThenReturnsSameText() {
+        String input = "lorem ipsum sed vinictus";
+
+        String output = AlternativeTextService.escapeAltText(input);
+        assertEquals(input, output);
+    }
+
+    @Test
+    public void givenTextWithoutAltTextWhenEscapingVisibleAltTextThenReturnsSameText() {
+        String input = "lorem ipsum sed vinictus";
+
+        String output = AlternativeTextService.escapeAltTextWithAllVisibleText(input);
+        assertEquals(input, output);
+    }
+
+    @Test
+    public void givenTextAndAltTextInInputWhenEscapingBasicAltTextThenReturnsEscapedText() {
+        String input = "additionalText \\alt{visibleText|readableText} additionalText";
+        String expected = "additionalText \\altEscapedvisibleText&altTextSeperator&readableText&altTextEnd& additionalText";
+
+        String output = AlternativeTextService.escapeAltText(input);
+
+        assertEquals(expected, output);
+    }
+
+    @Test
+    public void givenTextAndAltTextInInputWhenEscapingVisibleAltTextThenReturnsEscapedText() {
+        String input = "additionalText \\alt{visibleText|readableText} additionalText";
+        String expected = "additionalText \\altEscapedvisibleText&altTextSeperator&readableText&altTextEnd& additionalText";
+
+        String output = AlternativeTextService.escapeAltTextWithAllVisibleText(input);
+
+        assertEquals(expected, output);
+    }
+
+    @Test
+    public void givenTextAndAltTextWithSomeMathFormulaInInputWhenEscapingBasicAltTextThenReturnsSameText() {
+        String mathFormula = "\\(\\fraction{1}{2}\\)";
+        String input = "additionalText \\alt{" + mathFormula + "|readableText} additionalText";
+
+        String output = AlternativeTextService.escapeAltText(input);
+
+        assertEquals(input, output);
+    }
+
+    @Test
+    public void givenTextAndAltTextWithSomeMathFormulaInInputWhenEscapingVisibleAltTextThenReturnsEscapedText() {
+        String mathFormula = "\\(\\fraction{1}{2}\\)";
+        String input = "additionalText \\alt{" + mathFormula + "|readableText} additionalText";
+        String expected = "additionalText \\altEscaped" + mathFormula + "&altTextSeperator&readableText&altTextEnd& additionalText";
+
+        String output = AlternativeTextService.escapeAltTextWithAllVisibleText(input);
+
+        assertEquals(expected, output);
+    }
+
+    /*
+    * UnEscape tests
+    * */
+
+    @Test
+    public void givenTextWithoutAltTextWhenUnEscapingAltTextThenReturnsSameText() {
+        String input = "lorem ipsum sed vinictus";
+
+        String output = AlternativeTextService.unescapeAltText(input);
+        assertEquals(input, output);
+    }
+
+    @Test
+    public void givenTextWithoutAltTextWhenUnEscapingAllVisibleAltTextThenReturnsSameText() {
+        String input = "lorem ipsum sed vinictus";
+
+        String output = AlternativeTextService.unescapeAltText(input, true);
+        assertEquals(input, output);
+    }
+
+    @Test
+    public void givenTextAndAltTextInInputWhenUnEscapingAltTexThenReturnsEscapedText() {
+        String input = "additionalText \\altEscapedvisibleText&altTextSeperator&readableText&altTextEnd& additionalText";
+        String expected = "additionalText \\alt{visibleText|readableText} additionalText";
+
+        String output = AlternativeTextService.unescapeAltText(input);
+
+        assertEquals(expected, output);
+    }
+
+    @Test
+    public void givenTextAndAltTextInInputWhenUnEscapingAllVisibleAltTextThenReturnsEscapedText() {
+        String input = "additionalText \\altEscapedvisibleText&altTextSeperator&readableText&altTextEnd& additionalText";
+        String expected = "additionalText \\alt{visibleText|readableText} additionalText";
+
+        String output = AlternativeTextService.unescapeAltText(input, true);
+
+        assertEquals(expected, output);
+    }
+
+    @Test
+    public void givenTextAndAltTextWithSomeMathFormulaInInputWhenUnEscapingAltTextThenReturnsSameText() {
+        String mathFormula = "\\(\\fraction{1}{2}\\)";
+        String input = "additionalText \\altEscaped" + mathFormula + "&altTextSeperator&readableText&altTextEnd& additionalText";
+
+        String output = AlternativeTextService.unescapeAltText(input);
+
+        assertEquals(input, output);
+    }
+
+    @Test
+    public void givenTextAndAltTextWithSomeMathFormulaInInputWhenUnEscapingAllVisibleAltTextThenReturnsUnEscapedText() {
+        String mathFormula = "\\(\\fraction{1}{2}\\)";
+        String input = "additionalText \\altEscaped" + mathFormula + "&altTextSeperator&readableText&altTextEnd& additionalText";
+        String expected = "additionalText \\alt{" + mathFormula + "|readableText} additionalText";
+
+        String output = AlternativeTextService.unescapeAltText(input, true);
+
+        assertEquals(expected, output);
+    }
+
+}

--- a/src/test/java/com/lorepo/icplayer/client/module/text/GapInfoTestCase.java
+++ b/src/test/java/com/lorepo/icplayer/client/module/text/GapInfoTestCase.java
@@ -1,0 +1,38 @@
+package com.lorepo.icplayer.client.module.text;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class GapInfoTestCase {
+    private GapInfo gapInfo;
+
+    @Before
+    public void setUp() {
+        this.gapInfo = new GapInfo("someId", 0, false, false, 1);
+    }
+
+    @Test
+    public void givenTextWithoutEscapedAltTextWhenAddingAnswerThenAnswerIsSameAsGivenText() {
+        String input = "lorem ipsum";
+        gapInfo.addAnswer(input);
+
+        assertTrue(gapInfo.getAnswers().hasNext());
+        String answer = gapInfo.getAnswers().next();
+        assertEquals(input, answer);
+    }
+
+    @Test
+    public void givenTextWithEscapedAltTextWhenAddingAnswerThenAnswerIsUnEscapedText() {
+        String input = "\\altEscaped" + "Visible Text" + "&altTextSeperator&" + "Readable Text" + "&altTextEnd&";
+        String expected = "\\alt{Visible Text|Readable Text}";
+        gapInfo.addAnswer(input);
+
+        assertTrue(gapInfo.getAnswers().hasNext());
+        String answer = gapInfo.getAnswers().next();
+        assertEquals(expected, answer);
+    }
+
+}


### PR DESCRIPTION
I have moved some of functionalities to functions for better reading comprehension. Also code was duplicated in some cases (creating span element, adding answers), so I made the functions more generic.
Main change was to escape alt text before adding the answers to gap info in draggable gaps.