### PR TITLE
Fix for maintain state in limited check being always enabled, #7698

### DIFF
--- a/src/main/java/com/lorepo/icplayer/client/module/limitedcheck/LimitedCheckPresenter.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/limitedcheck/LimitedCheckPresenter.java
@@ -133,7 +133,9 @@ public class LimitedCheckPresenter implements IPresenter, IStateful, ICommandRec
         HashMap<String, String> state = new HashMap<String, String>();
 
         state.put("isVisible", Boolean.toString(isVisible));
-        state.put("isShowErrorsMode", Boolean.toString(view.isShowErrorsMode()));
+        if (model.getMaintainState()) {
+        	state.put("isShowErrorsMode", Boolean.toString(view.isShowErrorsMode()));
+        }
 
         return json.toJSONString(state);
     }
@@ -152,7 +154,7 @@ public class LimitedCheckPresenter implements IPresenter, IStateful, ICommandRec
             }
         }
         
-        if (decodedState.containsKey("isShowErrorsMode")) {
+        if (model.getMaintainState() && decodedState.containsKey("isShowErrorsMode")) {
         	boolean isShowErrorsMode = Boolean.parseBoolean(decodedState.get("isShowErrorsMode"));
         	if (isShowErrorsMode) {
         		Timer t = new Timer(){


### PR DESCRIPTION
Poprawia błąd gdzie Limited Check zachowuje się, jakby opcja Maintain State zawsze była zaznaczone, niezależnie od jej rzeczywistej wartości w modelu. 

Wersja testowa: https://test-7698-fix-dot-mauthor-dev.appspot.com/
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/7698--limited-check--pami%C4%99tanie-stanu-wci%C5%9Bni%C4%99cia-po-zmianie-stron/details?comment=1675219949