### PR TITLE
[YouTube_Addon] Allowed Youtube api to function regardless of api quoata, re #7715

### DIFF
--- a/addons/YouTube_Addon/src/presenter.js
+++ b/addons/YouTube_Addon/src/presenter.js
@@ -28,6 +28,8 @@
     }
 
      function doesConnectionExist() {
+         return true; // This method is temporarily disabled due to issues with youtube api
+
          var xhr = new ( window.ActiveXObject || XMLHttpRequest )( "Microsoft.XMLHTTP" );
 
          //YouTube API key is generated in lorepocorporate google account

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2020-04-17 Changed enabled youtube addon to work regardless of api quoata
 2020-03-05 Fix issue with XML entities in dropdown gap breaking show answers
 2020-03-05 Added HTML IDs to Choice options
 2020-03-04 Added maintain state property to Limited Check addon


### PR DESCRIPTION
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/realtime_cardwall?ticket=7715

Wersje testowa
poprawka:
https://test-7715-dot-mauthor-dev.appspot.com/embed/5652544267223040
poprawka + klucz api zmieniony na niepoprawny, żeby zasymulować przekroczenie limitu:
https://test-7715-2-dot-mauthor-dev.appspot.com/embed/5652544267223040
klucz api zmieniony na niepoprawny, żeby zasymulować przekroczenie limitu:
https://test-7715-3-dot-mauthor-dev.appspot.com/embed/5652544267223040

Tymczasowo wyłączyłem testowanie api w addonie Youtube, w związku z problemami z limitami youtube api.