### PR TITLE
Added resetPage and resetPageByName commands

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2020-04-20 Added resetPage and resetPageByName commands
 2020-03-05 Fix issue with XML entities in dropdown gap breaking show answers
 2020-03-05 Added HTML IDs to Choice options
 2020-03-04 Added maintain state property to Limited Check addon

--- a/src/main/java/com/lorepo/icplayer/client/content/services/JavaScriptPlayerServices.java
+++ b/src/main/java/com/lorepo/icplayer/client/content/services/JavaScriptPlayerServices.java
@@ -348,8 +348,8 @@ public class JavaScriptPlayerServices {
 				x.@com.lorepo.icplayer.client.content.services.JavaScriptPlayerServices::resetPage(I)(index - 1);
 			}
 			
-			commands.resetPageByName = function(pageName) {
-				x.@com.lorepo.icplayer.client.content.services.JavaScriptPlayerServices::resetPageByName(Ljava/lang/String;)(pageName);
+			commands.resetPageById = function(id) {
+				x.@com.lorepo.icplayer.client.content.services.JavaScriptPlayerServices::resetPageById(Ljava/lang/String;)(id);
 			}
 			
 			return commands;
@@ -1027,7 +1027,7 @@ public class JavaScriptPlayerServices {
 		this.playerServices.getCommands().resetPage(index);
 	}
 	
-	private void resetPageByName(String pageName) {
-		this.playerServices.getCommands().resetPageByName(pageName);
+	private void resetPageById(String id) {
+		this.playerServices.getCommands().resetPageById(id);
 	}
 }

--- a/src/main/java/com/lorepo/icplayer/client/content/services/JavaScriptPlayerServices.java
+++ b/src/main/java/com/lorepo/icplayer/client/content/services/JavaScriptPlayerServices.java
@@ -344,6 +344,14 @@ public class JavaScriptPlayerServices {
 				return x.@com.lorepo.icplayer.client.content.services.JavaScriptPlayerServices::getPageStamp()();
 			}
 			
+			commands.resetPage = function(index) {
+				x.@com.lorepo.icplayer.client.content.services.JavaScriptPlayerServices::resetPage(I)(index - 1);
+			}
+			
+			commands.resetPageByName = function(pageName) {
+				x.@com.lorepo.icplayer.client.content.services.JavaScriptPlayerServices::resetPageByName(Ljava/lang/String;)(pageName);
+			}
+			
 			return commands;
 		};
 
@@ -1013,5 +1021,13 @@ public class JavaScriptPlayerServices {
 
 	public String escapeXMLEntities(String text) {
 		return StringUtils.escapeXML(text);
+	}
+	
+	private void resetPage(int index) {
+		this.playerServices.getCommands().resetPage(index);
+	}
+	
+	private void resetPageByName(String pageName) {
+		this.playerServices.getCommands().resetPageByName(pageName);
 	}
 }

--- a/src/main/java/com/lorepo/icplayer/client/content/services/PlayerCommands.java
+++ b/src/main/java/com/lorepo/icplayer/client/content/services/PlayerCommands.java
@@ -58,9 +58,9 @@ public class PlayerCommands implements IPlayerCommands {
 		pageController.sendResetEvent();
 	}
 	
-	public void resetPageByName(String pageName) {
+	public void resetPageById(String id) {
 		for (IPage page: controller.getModel().getAllPages()) {
-			if (page.getName().equals(pageName)) {
+			if (page.getId().equals(id)) {
 				resetPage(page);
 			}
 		}

--- a/src/main/java/com/lorepo/icplayer/client/content/services/PlayerCommands.java
+++ b/src/main/java/com/lorepo/icplayer/client/content/services/PlayerCommands.java
@@ -1,6 +1,7 @@
 package com.lorepo.icplayer.client.content.services;
 
 import com.lorepo.icplayer.client.IPlayerController;
+import com.lorepo.icplayer.client.module.api.player.IPage;
 import com.lorepo.icplayer.client.module.api.player.IPlayerCommands;
 import com.lorepo.icplayer.client.module.api.player.PageScore;
 import com.lorepo.icplayer.client.page.PageController;
@@ -55,6 +56,31 @@ public class PlayerCommands implements IPlayerCommands {
 	public void reset() {
 		pageController.resetPageScore();
 		pageController.sendResetEvent();
+	}
+	
+	public void resetPageByName(String pageName) {
+		for (IPage page: controller.getModel().getAllPages()) {
+			if (page.getName().equals(pageName)) {
+				resetPage(page);
+			}
+		}
+	}
+	
+	@Override
+	public void resetPage(int index) {
+		IPage page = controller.getModel().getPage(index);
+		resetPage(page);
+	}
+	
+	private void resetPage(IPage page) {
+		if (page == pageController.getPage()) {
+			this.reset();
+		} else {
+			controller.getStateService().resetPageStates(page);			
+			PageScore oldScore = controller.getScoreService().getPageScoreById(page.getId());
+			PageScore newScore = oldScore.reset();
+			controller.getScoreService().setPageScore(page, newScore);		
+		}
 	}
 
 	@Override

--- a/src/main/java/com/lorepo/icplayer/client/content/services/StateService.java
+++ b/src/main/java/com/lorepo/icplayer/client/content/services/StateService.java
@@ -3,6 +3,7 @@ package com.lorepo.icplayer.client.content.services;
 import java.util.HashMap;
 
 import com.lorepo.icf.utils.JSONUtils;
+import com.lorepo.icplayer.client.module.api.player.IPage;
 import com.lorepo.icplayer.client.module.api.player.IStateService;
 
 public class StateService implements IStateService{
@@ -42,4 +43,14 @@ public class StateService implements IStateService{
 	public void resetStates() {
 		sessionState.clear();
 	}
+	
+	public void resetPageStates(IPage page) {
+		String id = page.getId();
+		for (String key: sessionState.keySet()) {
+			if (key.startsWith(id)) {
+				sessionState.remove(key);
+			}
+		}
+	}
+	
 }

--- a/src/main/java/com/lorepo/icplayer/client/module/api/player/IPlayerCommands.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/api/player/IPlayerCommands.java
@@ -7,6 +7,8 @@ public interface IPlayerCommands {
 	public void checkAnswers();
 	public void uncheckAnswers();
 	public void reset();
+	public void resetPage(int index);
+	public void resetPageByName(String pageName);
 	public void updateCurrentPageScore(boolean incrementCheckCounter);
 	public void resetPageScore();
 	public PageScore getCurrentPageScore();

--- a/src/main/java/com/lorepo/icplayer/client/module/api/player/IPlayerCommands.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/api/player/IPlayerCommands.java
@@ -8,7 +8,7 @@ public interface IPlayerCommands {
 	public void uncheckAnswers();
 	public void reset();
 	public void resetPage(int index);
-	public void resetPageByName(String pageName);
+	public void resetPageById(String id);
 	public void updateCurrentPageScore(boolean incrementCheckCounter);
 	public void resetPageScore();
 	public PageScore getCurrentPageScore();

--- a/src/main/java/com/lorepo/icplayer/client/module/api/player/IStateService.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/api/player/IStateService.java
@@ -9,4 +9,5 @@ public interface IStateService {
 	void loadFromString(String string);
 	HashMap<String, String> getStates();
 	void resetStates();
+	void resetPageStates(IPage page);
 }

--- a/src/test/java/com/lorepo/icplayer/client/mockup/services/CommandsMockup.java
+++ b/src/test/java/com/lorepo/icplayer/client/mockup/services/CommandsMockup.java
@@ -198,4 +198,16 @@ public class CommandsMockup implements IPlayerCommands {
 		return null;
 	}
 
+	@Override
+	public void resetPage(int index) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public void resetPageByName(String pageName) {
+		// TODO Auto-generated method stub
+		
+	}
+
 }

--- a/src/test/java/com/lorepo/icplayer/client/mockup/services/CommandsMockup.java
+++ b/src/test/java/com/lorepo/icplayer/client/mockup/services/CommandsMockup.java
@@ -205,7 +205,7 @@ public class CommandsMockup implements IPlayerCommands {
 	}
 
 	@Override
-	public void resetPageByName(String pageName) {
+	public void resetPageById(String id) {
 		// TODO Auto-generated method stub
 		
 	}


### PR DESCRIPTION
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/realtime_cardwall?ticket=7707
Wersja testowa: https://test-7707-dot-mauthor-dev.appspot.com/embed/5765590373367808

Dodałem dwie nowe komendy do player commands: resetPage(index) i resetPageByName(pageName). Poniżej przykład wywołania w AC:

EVENTSTART
Source:Single_State_Button1
SCRIPTSTART

  presenter.playerController.getCommands().resetPage(1);

SCRIPTEND
EVENTEND