### PR TITLE
[MultiAudio] Do not handle ItemStopped event, when item is null, re #7732

### DIFF
--- a/addons/MultiAudio/src/presenter.js
+++ b/addons/MultiAudio/src/presenter.js
@@ -52,9 +52,9 @@ function AddonMultiAudio_create(){
                     showDraggableItem(itemID);
                 }
             }
-        } else if (eventName == "ItemSelected") {
+        } else if (eventName == "ItemSelected" && eventData.item !== null) { // when ImageSource deselects item, then item is null
             var itemID = getItemIdFromEvent(eventData.item);
-            applySelectedClass(itemID);
+            this.applySelectedClass(itemID);
         }
     };
 
@@ -65,7 +65,7 @@ function AddonMultiAudio_create(){
         return addonAndItemIds[1];
     }
 
-    function applySelectedClass(itemID) {
+    presenter.applySelectedClass = function(itemID) {
         if (presenter.globalModel["Interface"] != "Draggable items") return;
         var keys = Object.keys(presenter.draggableItems);
         for (var i = 0; i < keys.length; i++) {

--- a/addons/MultiAudio/test/TestEvents.js
+++ b/addons/MultiAudio/test/TestEvents.js
@@ -1,0 +1,45 @@
+TestCase('[MultiAudio] Event handling tests', {
+    setUp: function () {
+        this.presenter = AddonMultiAudio_create();
+
+        this.presenter.addonID = "MultiAudio1";
+        this.stubs = {
+            applySelectedClass: sinon.stub()
+        };
+        this.presenter.applySelectedClass = this.stubs.applySelectedClass;
+    },
+
+    'test given ItemSelected event with item set to null when handling event then does not call applySelectedClass': function () {
+        var eventName = "ItemSelected";
+        var eventData = {
+            item: null
+        };
+        this.presenter.onEventReceived(eventName, eventData);
+
+        assertEquals(0, this.stubs.applySelectedClass.callCount);
+    },
+
+    'test given ItemSelected event with item name begining with addonID when handling event then does call applySelectedClass': function () {
+        var expectedArg = "Expected";
+        var eventName = "ItemSelected";
+        var eventData = {
+            item: this.presenter.addonID + "-" + expectedArg
+        };
+        this.presenter.onEventReceived(eventName, eventData);
+
+        assertEquals(1, this.stubs.applySelectedClass.callCount);
+        assertTrue(this.stubs.applySelectedClass.calledWith(expectedArg));
+    },
+
+    'test given ItemSelected event with name not begining with addonID when handling event then does call applySelectedClass with null': function () {
+        var expectedArg = "Expected";
+        var eventName = "ItemSelected";
+        var eventData = {
+            item: "-" + expectedArg
+        };
+        this.presenter.onEventReceived(eventName, eventData);
+
+        assertEquals(1, this.stubs.applySelectedClass.callCount);
+        assertTrue(this.stubs.applySelectedClass.calledWith(null));
+    }
+});

--- a/addons/MultiAudio/test/ValidateState.js
+++ b/addons/MultiAudio/test/ValidateState.js
@@ -2,7 +2,7 @@ ValidateState = TestCase("Validate Get And Set State Multi Audio");
 
 ValidateState.prototype.setUp = function() {
     this.presenter = AddonMultiAudio_create();
-    this.model = {
+    this.presenter.globalModel = {
     		"Files" : [{
     		           "ID"  		 : "1",
     		           "Mp3" 		 : "/file/serve/123",

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2020-06-08 Added checking if event item is null in MultiAudio
 2020-06-04 Modified youtube addon to use new mauthor api
 2020-06-02 Fix problem with page size when static footer is enabled
 2020-05-26 Fixed issue with Paragraph when the default layout is not the initial one


### PR DESCRIPTION
The error was in getItemIdFromEvent function. The item variable which was being passed to it was set to null, and that function tried to call split on null - which caused exception.