### PR TITLE
changed the way score is rounded, re #7738

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2020-06-26 Changed the way lesson score is rounded
 2020-06-20 Add checking if gap is audio gap
 2020-06-19 Add getresponseindex to commands in Feedback addon
 2020-06-17 Fix page weight in utils.

--- a/src/main/java/com/lorepo/icplayer/public/libs/player-utils.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/player-utils.js
@@ -78,7 +78,7 @@
                     paginatedResults[count] = {
                         "page_number": (i + 1),
                         "page_name": page.getName(),
-                        "score": Math.floor(pageScaledScore * 100) / 100,
+                        "score": Math.round(pageScaledScore * 100) / 100,
                         "absolute_score": score['score'],
                         "max_score": score['maxScore'],
                         "errors_count": score['errorCount'] ? score['errorCount'] : 0,
@@ -94,7 +94,7 @@
             var scaledScore = 0;
             if (count > 0) {
                 if (sumOfWeights) {
-                    scaledScore = Math.floor((sumOfScaledScore / sumOfWeights) * 100) / 100;
+                    scaledScore = Math.round((sumOfScaledScore / sumOfWeights) * 100) / 100;
                 } else {
                     scaledScore = 1;
                 }


### PR DESCRIPTION
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/7738--support--agradeahead--error-with-scorm-scoring-((highly-urgent)/details?comment=1679302102
Wersja testowa: https://test-7738-dot-lorepocorporate.appspot.com/

Zmieniłem sposób obliczania score z floor na round.