### PR TITLE
Printable addons now get custom css classes, re #7787

### DIFF
--- a/addons/Connection/src/presenter.js
+++ b/addons/Connection/src/presenter.js
@@ -1931,7 +1931,6 @@ function AddonConnection_create() {
         var $root = $("<div></div>")
         $root.attr('id', model.ID);
         $root.addClass('printable_addon_Connection');
-        $root.addClass('printable_module');
         $root.css("max-width", model["Width"]+"px");
         $root.css("min-height", model["Height"]+"px");
         $root.html('<table class="connectionContainer">' +

--- a/addons/Heading/src/presenter.js
+++ b/addons/Heading/src/presenter.js
@@ -186,7 +186,6 @@ function AddonHeading_create () {
         var $root = $('<div></div>');
         $root.attr('id',configuration.ID);
         $root.addClass('printable_addon_Heading');
-        $root.addClass('printable_module');
         $root.css("max-width", model["Width"]+"px");
         $root.css("min-height", model["Height"]+"px");
 

--- a/addons/Text_Selection/src/presenter.js
+++ b/addons/Text_Selection/src/presenter.js
@@ -1679,7 +1679,6 @@ function AddonText_Selection_create() {
         var $view = $("<div></div>");
         $view.attr("id", model.ID);
         $view.addClass("printable_addon_Text_Selection");
-        $view.addClass("printable_module");
         $view.css("max-width", model["Width"]+"px");
         $view.css("min-height", model["Height"]+"px");
 

--- a/addons/TrueFalse/src/presenter.js
+++ b/addons/TrueFalse/src/presenter.js
@@ -1080,7 +1080,6 @@ function AddonTrueFalse_create() {
         var $view = $("<div></div>");
         $view.attr('id',model.ID);
         $view.addClass('printable_addon_TrueFalse');
-        $view.addClass('printable_module');
         $view.css("max-width", model["Width"]+"px");
         var $table = $("<table></table>");
         var $tbody = $("<tbody></tbody>");

--- a/src/main/java/com/lorepo/icplayer/client/PrintableContentParser.java
+++ b/src/main/java/com/lorepo/icplayer/client/PrintableContentParser.java
@@ -4,7 +4,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.Random;
+import com.google.gwt.user.client.ui.HTML;
 import com.lorepo.icplayer.client.model.Content;
 import com.lorepo.icplayer.client.model.ModuleList;
 import com.lorepo.icplayer.client.model.page.Page;
@@ -152,4 +154,13 @@ public class PrintableContentParser {
 		result += "</div>";
 		return result;
 	};
+	
+	public static String addClassToPrintableModule(String printableHTML, String className) {
+		Element element = (new HTML(printableHTML)).getElement().getFirstChildElement();
+		element.addClassName("printable_module");
+		if (className.length() > 0) {
+			element.addClassName("printable_module-" + className);
+		}
+		return element.getString();
+	}
 }

--- a/src/main/java/com/lorepo/icplayer/client/module/addon/AddonModel.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/addon/AddonModel.java
@@ -21,6 +21,7 @@ import com.lorepo.icf.properties.IVideoProperty;
 import com.lorepo.icf.utils.StringUtils;
 import com.lorepo.icf.utils.URLUtils;
 import com.lorepo.icf.utils.XMLUtils;
+import com.lorepo.icplayer.client.PrintableContentParser;
 import com.lorepo.icplayer.client.module.BasicModuleModel;
 import com.lorepo.icplayer.client.module.IPrintableModuleModel;
 import com.lorepo.icplayer.client.module.Printable;
@@ -166,10 +167,12 @@ public class AddonModel extends BasicModuleModel implements IPrintableModuleMode
 		JavaScriptObject jsModel = createJsModel(this);
 		String className = this.getStyleClass();
 		
-		return getPrintableHTML(addonName, jsModel, className, showAnswers);
+		String result = getPrintableHTML(addonName, jsModel,showAnswers);
+		result = PrintableContentParser.addClassToPrintableModule(result, className);
+		return result;
 	}
 	
-	private native String getPrintableHTML(String addonName, JavaScriptObject model, String className, boolean showAnswers) /*-{
+	private native String getPrintableHTML(String addonName, JavaScriptObject model, boolean showAnswers) /*-{
 		if($wnd.window[addonName] == null){
 			return null;
 		}
@@ -179,13 +182,7 @@ public class AddonModel extends BasicModuleModel implements IPrintableModuleMode
 			return null;
 		}
 		
-		var printableHTML = presenter.getPrintableHTML(model, showAnswers);
-		if (className) {
-			var $printable = $wnd.$(printableHTML);
-			$printable.addClass("printable_module-" + className);
-			printableHTML = $printable[0].outerHTML;
-		}
-		return printableHTML;
+		return presenter.getPrintableHTML(model, showAnswers);
 	}-*/;
 
 	@Override

--- a/src/main/java/com/lorepo/icplayer/client/module/addon/AddonModel.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/addon/AddonModel.java
@@ -164,11 +164,12 @@ public class AddonModel extends BasicModuleModel implements IPrintableModuleMode
 		
 		String addonName = "Addon" + getAddonId() + "_create";
 		JavaScriptObject jsModel = createJsModel(this);
+		String className = this.getStyleClass();
 		
-		return getPrintableHTML(addonName, jsModel, showAnswers);
+		return getPrintableHTML(addonName, jsModel, className, showAnswers);
 	}
 	
-	private native String getPrintableHTML(String addonName, JavaScriptObject model, boolean showAnswers) /*-{
+	private native String getPrintableHTML(String addonName, JavaScriptObject model, String className, boolean showAnswers) /*-{
 		if($wnd.window[addonName] == null){
 			return null;
 		}
@@ -178,7 +179,13 @@ public class AddonModel extends BasicModuleModel implements IPrintableModuleMode
 			return null;
 		}
 		
-		return presenter.getPrintableHTML(model, showAnswers);
+		var printableHTML = presenter.getPrintableHTML(model, showAnswers);
+		if (className) {
+			var $printable = $wnd.$(printableHTML);
+			$printable.addClass("printable_module-" + className);
+			printableHTML = $printable[0].outerHTML;
+		}
+		return printableHTML;
 	}-*/;
 
 	@Override

--- a/src/main/java/com/lorepo/icplayer/client/module/choice/ChoiceModel.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/choice/ChoiceModel.java
@@ -662,7 +662,8 @@ public class ChoiceModel extends BasicModuleModel implements IWCAGModuleModel, I
 	@Override
 	public String getPrintableHTML(boolean showAnswers) {
 		ChoicePrintable printable = new ChoicePrintable(this);
-		String result = printable.getPrintableHTML(showAnswers);
+		String className = this.getStyleClass();
+		String result = printable.getPrintableHTML(className, showAnswers);
 		return result;
 	}
 

--- a/src/main/java/com/lorepo/icplayer/client/module/choice/ChoicePrintable.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/choice/ChoicePrintable.java
@@ -15,8 +15,12 @@ public class ChoicePrintable {
 		this.model = model;
 	}
 	
-	public String getPrintableHTML(boolean showAnswers) {
+	public String getPrintableHTML(String className, boolean showAnswers) {
 		if (model.getPrintable() == PrintableMode.NO) return null;
+		
+		if (className.length() > 0) {
+			className = "printable_module-" + className;
+		}
 		
 		ArrayList<ChoiceOption> orderedOptions = new ArrayList<ChoiceOption>();
 		for (int i = 0; i < model.getOptionCount(); i++) {
@@ -35,7 +39,7 @@ public class ChoicePrintable {
 			optionHTMLs.add(optionHTML);
 		}
 		
-		String result = "<div class=\"printable_ic_choice printable_module\" id=\"" + model.getId() +"\"><ol type=\"A\">";
+		String result = "<div class=\"printable_ic_choice printable_module " + className + "\" id=\"" + model.getId() +"\"><ol type=\"A\">";
 		for (String optionHTML: optionHTMLs) {
 			result += optionHTML;
 		}

--- a/src/main/java/com/lorepo/icplayer/client/module/choice/ChoicePrintable.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/choice/ChoicePrintable.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.List;
 
 import com.google.gwt.user.client.Random;
+import com.lorepo.icplayer.client.PrintableContentParser;
 import com.lorepo.icplayer.client.module.Printable.PrintableMode;
 
 public class ChoicePrintable {
@@ -17,10 +18,6 @@ public class ChoicePrintable {
 	
 	public String getPrintableHTML(String className, boolean showAnswers) {
 		if (model.getPrintable() == PrintableMode.NO) return null;
-		
-		if (className.length() > 0) {
-			className = "printable_module-" + className;
-		}
 		
 		ArrayList<ChoiceOption> orderedOptions = new ArrayList<ChoiceOption>();
 		for (int i = 0; i < model.getOptionCount(); i++) {
@@ -39,11 +36,13 @@ public class ChoicePrintable {
 			optionHTMLs.add(optionHTML);
 		}
 		
-		String result = "<div class=\"printable_ic_choice printable_module " + className + "\" id=\"" + model.getId() +"\"><ol type=\"A\">";
+		String result = "<div class=\"printable_ic_choice\" id=\"" + model.getId() +"\"><ol type=\"A\">";
 		for (String optionHTML: optionHTMLs) {
 			result += optionHTML;
 		}
 		result += "</ol></div>";
+		
+		result = PrintableContentParser.addClassToPrintableModule(result, className);
 		
 		return result;
 	}

--- a/src/main/java/com/lorepo/icplayer/client/module/image/ImageModule.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/image/ImageModule.java
@@ -317,7 +317,8 @@ public class ImageModule extends BasicModuleModel implements IWCAGModuleModel, I
 	@Override
 	public String getPrintableHTML(boolean showAnswers) {
 		ImagePrintable printable = new ImagePrintable(this);
-		String result = printable.getPrintableHTML(showAnswers);	
+		String className = this.getStyleClass();
+		String result = printable.getPrintableHTML(className, showAnswers);	
 		return result;
 	}
 

--- a/src/main/java/com/lorepo/icplayer/client/module/image/ImagePrintable.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/image/ImagePrintable.java
@@ -20,13 +20,17 @@ public class ImagePrintable {
 		style.setLeft((width - image.getWidth())/2, Style.Unit.PX);
 	}
 
-	public String getPrintableHTML(boolean showAnswers) {
+	public String getPrintableHTML(String className, boolean showAnswers) {
 		if (model.getPrintable() == PrintableMode.NO) return null;
+		
+		if (className.length() > 0) {
+			className = "printable_module-" + className;
+		}
 		
 		String rootStyle = "width:"+Integer.toString(model.getWidth())+"px;";
 		rootStyle += "height:"+Integer.toString(model.getHeight())+"px;";
 		rootStyle += "position: relative;";
-		String result = "<div class=\"printable_ic_image printable_module\" id=\"" + model.getId() + "\" style=\"" + rootStyle + "\">";
+		String result = "<div class=\"printable_ic_image printable_module " + className + "\" id=\"" + model.getId() + "\" style=\"" + rootStyle + "\">";
 		
 		Image image = new Image();
 		image.setUrl(model.getUrl());

--- a/src/main/java/com/lorepo/icplayer/client/module/image/ImagePrintable.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/image/ImagePrintable.java
@@ -2,6 +2,7 @@ package com.lorepo.icplayer.client.module.image;
 
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.user.client.ui.Image;
+import com.lorepo.icplayer.client.PrintableContentParser;
 import com.lorepo.icplayer.client.module.Printable.PrintableMode;
 import com.lorepo.icplayer.client.module.image.ImageModule.DisplayMode;
 
@@ -23,14 +24,10 @@ public class ImagePrintable {
 	public String getPrintableHTML(String className, boolean showAnswers) {
 		if (model.getPrintable() == PrintableMode.NO) return null;
 		
-		if (className.length() > 0) {
-			className = "printable_module-" + className;
-		}
-		
 		String rootStyle = "width:"+Integer.toString(model.getWidth())+"px;";
 		rootStyle += "height:"+Integer.toString(model.getHeight())+"px;";
 		rootStyle += "position: relative;";
-		String result = "<div class=\"printable_ic_image printable_module " + className + "\" id=\"" + model.getId() + "\" style=\"" + rootStyle + "\">";
+		String result = "<div class=\"printable_ic_image\" id=\"" + model.getId() + "\" style=\"" + rootStyle + "\">";
 		
 		Image image = new Image();
 		image.setUrl(model.getUrl());
@@ -45,6 +42,8 @@ public class ImagePrintable {
 		}
 		result += image.getElement().getString();
 		result += "</div>";
+		
+		result = PrintableContentParser.addClassToPrintableModule(result, className);
 		
 		return result;
 	}

--- a/src/main/java/com/lorepo/icplayer/client/module/sourcelist/SourceListModule.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/sourcelist/SourceListModule.java
@@ -31,7 +31,7 @@ public class SourceListModule extends BasicModuleModel implements IWCAGModuleMod
 	
 	public SourceListModule() {
 		super("Source list", DictionaryWrapper.get("source_list_module"));
-		
+
 		initData();
 		addPropertyItems(true);
 		addPropertyRemovable();
@@ -471,7 +471,8 @@ public class SourceListModule extends BasicModuleModel implements IWCAGModuleMod
 	@Override
 	public String getPrintableHTML(boolean showAnswers) {
 		SourceListPrintable printable = new SourceListPrintable(this);
-		String result = printable.getPrintableHTML(showAnswers);
+		String className = this.getStyleClass();
+		String result = printable.getPrintableHTML(className, showAnswers);
 		return result;
 	}
 

--- a/src/main/java/com/lorepo/icplayer/client/module/sourcelist/SourceListPrintable.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/sourcelist/SourceListPrintable.java
@@ -10,10 +10,14 @@ public class SourceListPrintable {
 		this.model = model;
 	}
 	
-	public String getPrintableHTML(boolean showAnswers) {
+	public String getPrintableHTML(String className, boolean showAnswers) {
 		if (model.getPrintable() == PrintableMode.NO) return null;
 		
-		String result = "<div class=\"printable_ic_sourceList printable_module\" id=\"" + model.getId() +"\">";
+		if (className.length() > 0) {
+			className = "printable_module-" + className;
+		}
+		
+		String result = "<div class=\"printable_ic_sourceList printable_module " + className + "\" id=\"" + model.getId() +"\">";
 		int itemCount = model.getItemCount();
 		for (int i = 0; i < itemCount; i++) {
 			result += model.getItem(i);

--- a/src/main/java/com/lorepo/icplayer/client/module/sourcelist/SourceListPrintable.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/sourcelist/SourceListPrintable.java
@@ -1,5 +1,6 @@
 package com.lorepo.icplayer.client.module.sourcelist;
 
+import com.lorepo.icplayer.client.PrintableContentParser;
 import com.lorepo.icplayer.client.module.Printable.PrintableMode;
 
 public class SourceListPrintable {
@@ -13,11 +14,7 @@ public class SourceListPrintable {
 	public String getPrintableHTML(String className, boolean showAnswers) {
 		if (model.getPrintable() == PrintableMode.NO) return null;
 		
-		if (className.length() > 0) {
-			className = "printable_module-" + className;
-		}
-		
-		String result = "<div class=\"printable_ic_sourceList printable_module " + className + "\" id=\"" + model.getId() +"\">";
+		String result = "<div class=\"printable_ic_sourceList\" id=\"" + model.getId() +"\">";
 		int itemCount = model.getItemCount();
 		for (int i = 0; i < itemCount; i++) {
 			result += model.getItem(i);
@@ -26,6 +23,9 @@ public class SourceListPrintable {
 			}
 		}
 		result += "</div>";
+		
+		result = PrintableContentParser.addClassToPrintableModule(result, className);
+		
 		return result;
 	}
 }

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextModel.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextModel.java
@@ -1228,7 +1228,8 @@ public class TextModel extends BasicModuleModel implements IWCAGModuleModel, IPr
 	@Override
 	public String getPrintableHTML(boolean showAnswers) {
 		TextPrintable printable = new TextPrintable(this);
-		String result = printable.getPrintableHTML(showAnswers);
+		String className = this.getStyleClass();
+		String result = printable.getPrintableHTML(className, showAnswers);
 		return result;
 	}
 

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextPrintable.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextPrintable.java
@@ -15,7 +15,7 @@ public class TextPrintable {
 		this.model = model;
 	}
 	
-	public String getPrintableHTML(boolean showAnswers) {
+	public String getPrintableHTML(String className, boolean showAnswers) {
 		if (model.getPrintable() == PrintableMode.NO) {
 			return null;
 		}
@@ -28,7 +28,11 @@ public class TextPrintable {
 		// Convert all dropdowns to a printer-friendly format
 		parsedText = makePrintableDropdowns(parsedText, showAnswers);
 		
-		String result = "<div class=\"printable_ic_text printable_module\" id=\"" + model.getId() +"\">" + parsedText + "</div>";	
+		if (className.length() > 0) {
+			className = "printable_module-" + className;
+		}
+		
+		String result = "<div class=\"printable_ic_text printable_module " + className + "\" id=\"" + model.getId() +"\">" + parsedText + "</div>";	
 		return result;
 	}
 	

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextPrintable.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextPrintable.java
@@ -5,6 +5,7 @@ import java.util.Iterator;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NodeList;
 import com.google.gwt.user.client.ui.HTML;
+import com.lorepo.icplayer.client.PrintableContentParser;
 import com.lorepo.icplayer.client.module.Printable.PrintableMode;
 
 public class TextPrintable {
@@ -28,11 +29,8 @@ public class TextPrintable {
 		// Convert all dropdowns to a printer-friendly format
 		parsedText = makePrintableDropdowns(parsedText, showAnswers);
 		
-		if (className.length() > 0) {
-			className = "printable_module-" + className;
-		}
-		
-		String result = "<div class=\"printable_ic_text printable_module " + className + "\" id=\"" + model.getId() +"\">" + parsedText + "</div>";	
+		String result = "<div class=\"printable_ic_text\" id=\"" + model.getId() +"\">" + parsedText + "</div>";
+		result = PrintableContentParser.addClassToPrintableModule(result, className);
 		return result;
 	}
 	


### PR DESCRIPTION
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/7787--pearson--drukowanie-%E2%80%93%C2%A0dodanie-mo%C5%BCliwo%C5%9Bci-stylowania-podgl%C4%85du/details?comment=1681948091
Wersja testowa: https://test-7787-dot-mauthor-dev.ew.r.appspot.com

Moduły w widoku drukowalnym dostają klasę css tworzoną na bazie tej ustawionej w edytorze (dodawane jest printable_module- na początku żeby uniknąć konfliktów).