### PR TITLE
[IWB Toolbar] Fixed marker state not being saved on touch end event, re #7789

### DIFF
--- a/addons/IWB_Toolbar/src/presenter.js
+++ b/addons/IWB_Toolbar/src/presenter.js
@@ -498,6 +498,7 @@ function AddonIWB_Toolbar_create() {
         presenter.tmp_ctx.clearRect(0, 0, presenter.iwb_tmp_canvas.width, presenter.iwb_tmp_canvas.height);
 
         presenter.points = [];
+        presenter.markerDataUrl = presenter.markerCanvas[0].toDataURL('image/png');
     };
 
     presenter.markerMouseDownHandler = function IWB_Toolbar_markerMouseDownHandler(e) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2020-09-11 Fixed state of marker tool in IWB Toolbar not being saved
 2020-08-17 Added property to Assesment Navigation Bar for switching off the randomization
 2020-07-21 Changed icon of YouTube addon
 2020-06-26 Changed the way lesson score is rounded


### PR DESCRIPTION
Wersja testowa: https://test-7780-dot-mauthor-dev.ew.r.appspot.com/embed/5744100454170624
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/7780--support--filipiny--adnotacje-w-mlibro-ios-android-nie-zapisuj%C4%85-si%C4%99-po/details?comment=1682124891

Na urządzeniach mobilnych nie był zapisywany stan marker'a w addonie IWB Toolbar (zapisywanie było dodane dla eventu mouseup, ale nie touchend). Błąd został poprawiony.