### PR TITLE
Added single_column_print and double_column_print to printable lesson, re #7801

### DIFF
--- a/src/main/java/com/lorepo/icplayer/client/PrintableContentParser.java
+++ b/src/main/java/com/lorepo/icplayer/client/PrintableContentParser.java
@@ -40,33 +40,33 @@ public class PrintableContentParser {
 	}
 	
 	public interface PrintableHtmlTemplates extends SafeHtmlTemplates {
-		@Template("<tr class=\"printable_header\" style=\"height:{0}px;width:100%;\"><td>{1}</td></tr>")
+		@Template("<tr class=\"printable_header single_column_print\" style=\"height:{0}px;width:100%;\"><td>{1}</td></tr>")
 	    SafeHtml pageHeader(int height, SafeHtml content);
 		
-		@Template("<tr><td class='printable_content' style='"
+		@Template("<tr><td class='printable_content {0}' style='"
 				+ "vertical-align: top;"
-				+ " columns: {0};"
-				+ "-webkit-columns:{0};"
-				+ "-moz-columns: {0};"
-				+ " column-gap: 40px;"
-				+ "'>{1}</td></tr>")
-	    SafeHtml pageContent(int columns, SafeHtml content);
-		
-		@Template("<tr><td class='printable_content'><div style='"
-				+ "vertical-align: top;"
-				+ "height: {0}px;"
-				+ "width: 100%;"
 				+ " columns: {1};"
 				+ "-webkit-columns:{1};"
 				+ "-moz-columns: {1};"
 				+ " column-gap: 40px;"
+				+ "'>{2}</td></tr>")
+	    SafeHtml pageContent(String classes, int columns, SafeHtml content);
+		
+		@Template("<tr><td class='printable_content {0}'><div style='"
+				+ "vertical-align: top;"
+				+ "height: {1}px;"
+				+ "width: 100%;"
+				+ " columns: {2};"
+				+ "-webkit-columns:{2};"
+				+ "-moz-columns: {2};"
+				+ " column-gap: 40px;"
 				+ " column-fill: auto;"
 				+ "-webkit-column-fill: auto;"
 				+ "-moz-column-fill: auto;"
-				+ "'>{2}</div></td></tr>")
-	    SafeHtml pageContentFullHeight(int height, int columns, SafeHtml content);
+				+ "'>{3}</div></td></tr>")
+	    SafeHtml pageContentFullHeight(String classes, int height, int columns, SafeHtml content);
 		
-		@Template("<tr class=\"printable_footer\" style=\"height:{0}px;width:100%;\"><td>{1}</td></tr>")
+		@Template("<tr class=\"printable_footer single_column_print\" style=\"height:{0}px;width:100%;\"><td>{1}</td></tr>")
 	    SafeHtml pageFooter(int height, SafeHtml content);
 	}
 	private static final PrintableHtmlTemplates TEMPLATE = GWT.create(PrintableHtmlTemplates.class);
@@ -232,13 +232,18 @@ public class PrintableContentParser {
 			result += TEMPLATE.pageHeader(headerHeight, headerHTML).asString();
 		}
 
-		int columns = enableTwoColumnPrint ? 2 : 1;
+		int columns = 1;
+		String column_class = "single_column_print";
+		if (enableTwoColumnPrint) {
+			columns = 2;
+			column_class = "double_column_print";
+		}
 		SafeHtml safeContent = SafeHtmlUtils.fromTrustedString(content);
 
 		if (fullHeight) {
-			result += TEMPLATE.pageContentFullHeight(contentHeight, columns, safeContent).asString();
+			result += TEMPLATE.pageContentFullHeight(column_class, contentHeight, columns, safeContent).asString();
 		} else {
-			result += TEMPLATE.pageContent(columns, safeContent).asString();
+			result += TEMPLATE.pageContent(column_class, columns, safeContent).asString();
 		}
 		
 		if (footerHeight > 0) {
@@ -270,7 +275,7 @@ public class PrintableContentParser {
 	}-*/;
 	
 	private String wrapOpeningPlayerPage(String content) {
-		return "<div class=\"printable_opening_player_page\">" + content + "</div>";
+		return "<div class=\"printable_opening_player_page single_column_print\">" + content + "</div>";
 	}
 	
 	public String generatePrintableHTMLForPages(List<Page> pages, boolean randomizePages, boolean randomizeModules, boolean showAnswers) {


### PR DESCRIPTION
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/realtime_cardwall?ticket=7801
Wersja testowa: https://test-7801-dot-mauthor-dev.appspot.com/

Dodałem klasy css single_column_print i double_column_print na następującej zasadzie.
-Header zawsze dostaje single_column_print 
-Footer zawsze dostaje single_column_print 
-Body dostaje single_column_print lub double_column_print w zależności od tego, co zostało ustawione w konfiguracji
-Wrapper pierwszej strony mauthora zawsze dostaje single_column_print ( słowo wyjaśnienia - jeżeli na stronie wydruku znajdują się moduły pochodzące zarówno z pierwszej jak i z pozostałych stron mauthora, to moduły z pierwszej strony zostają owinięte w div z klasą printable_opening_player_page która tak ustawia ich style, aby zawsze wyświetlały się na pełnej szerokości. Jeżeli na danej stronie wydruku znajdują się wyłącznie moduły z pierwszej strony mauthora, to po prostu dostaje tryb jednokolumnowy)