### PR TITLE
[AudioPlaylist] Remove waiting for metadata loading as it wont happen on iOS without play command and hide volume control button, re 7824

### DIFF
--- a/addons/AudioPlaylist/src/presenter.js
+++ b/addons/AudioPlaylist/src/presenter.js
@@ -113,6 +113,10 @@ function AddonAudioPlaylist_create() {
         if (!isPreview) {
             presenter.audio = presenter.view.getElementsByTagName("audio")[0];
             presenter.addHandlers();
+
+            if (MobileUtils.isSafariMobile(navigator.userAgent)) {
+                presenter.viewItems.volumeButton.style.visibility = "hidden";
+            }
         }
 
         updateBallPosition();

--- a/addons/AudioPlaylist/src/presenter.js
+++ b/addons/AudioPlaylist/src/presenter.js
@@ -369,6 +369,8 @@ function AddonAudioPlaylist_create() {
         if (wasSelected && !presenter.configuration.stopPlaying) {
             presenter.play();
         }
+
+        return wasSelected;
     };
 
     presenter.addHandlers = function AddonAudioPlaylist_addHandlers() {
@@ -409,11 +411,11 @@ function AddonAudioPlaylist_create() {
     };
 
     presenter.next = function () {
-        presenter.changeItem(presenter.state.currentItemIndex + 1);
+        return presenter.changeItem(presenter.state.currentItemIndex + 1);
     };
 
     presenter.prev = function () {
-        presenter.changeItem(presenter.state.currentItemIndex - 1);
+        return presenter.changeItem(presenter.state.currentItemIndex - 1);
     };
 
     presenter.sendEvent = function (name, data) {
@@ -500,10 +502,6 @@ function AddonAudioPlaylist_create() {
             score: ""
         });
         presenter.next();
-
-        if (!presenter.configuration.stopPlaying) {
-            presenter.play();
-        }
     }
 
     function AddonAudioPlaylist___onAudioPlaying() {
@@ -542,13 +540,12 @@ function AddonAudioPlaylist_create() {
         var clickedWidth = ev.offsetX;
 
         var value = clickedWidth / width;
-        var percent = Math.round(value  * 100);
+        var percent = Math.round(value * 100);
+        presenter.viewItems.volumeBarFill.style.width = percent + "%";
 
         if (presenter.audio) {
             presenter.audio.volume = value;
         }
-
-        presenter.viewItems.volumeBarFill.style.width = percent + "%";
     }
 
     function AddonAudioPlaylist__sliderMouseDragStartHandler(ev) {
@@ -648,7 +645,6 @@ function AddonAudioPlaylist_create() {
     }
 
      function AddonAudioPlaylistItemWrapper__audioDurationChange(ev) {
-        console.log(this.name + " track duration loaded");
         this.time.innerText = StringUtils.timeFormat(isNaN(this.audio.duration) ? 0 : this.audio.duration);
         this.audio.removeEventListener("durationchange", AddonAudioPlaylistItemWrapper__audioDurationChange);
         this.audio = null;

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2020-10-27 Fixed issue with AudioPlaylist on iOS
 2020-10-23 Fixed issue with setting pages as nonreportable by adaptive learning service
 2020-10-22 Remove allOK event from Text
 2020-10-22 Fixed problem with null elements in LineNumber after getState call


### PR DESCRIPTION
Usunąłem czekanie na załadowanie metadanych audio - na iOSie wykona się to tylko wtedy kiedy uruchomione zostanie play() - co w addonie było wstrzymywane dopóki nie załadowały się metadane.
Schowany także został przycisk do manipulowania głośnością https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/Using_HTML5_Audio_Video/Device-SpecificConsiderations/Device-SpecificConsiderations.html (Volume Control in JavaScript)