### PR TITLE
Removed adding of wrapper for gaps, re #7828

### DIFF
--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextParser.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextParser.java
@@ -113,7 +113,6 @@ public class TextParser {
 				}
 				parserResult.parsedText = parseAltText(parserResult.parsedText);
 				parserResult.parsedText = parseDefinitions(parserResult.parsedText);
-				parserResult.parsedText = setNonBreakingGaps(parserResult.parsedText);
 			}
 		} catch (Exception e) {
 			parserResult.parsedText = "#ERROR#";
@@ -177,7 +176,6 @@ public class TextParser {
 		result.parsedText = parseOldSyntax(result.parsedText);
 		result.parsedText = parseDefinitions(result.parsedText);
 		result.parsedText = parseAudio(result.parsedText);
-		result.parsedText = setNonBreakingGaps(result.parsedText);
 
 		result.hasSyntaxError = hasSyntaxError;
 		return result;
@@ -1131,43 +1129,6 @@ public class TextParser {
 	public void setIsNumericOnly(boolean isNumericOnly) {
 		this.isNumericOnly = isNumericOnly;
 	}
-
-	public String setNonBreakingGaps(String srcText) {
-	    String inputReplacer = "##INPUT_ELEMENT_REPLACER##";
-        String pattern = "[^\\s>]*" + inputReplacer + "[^\\s<]*";
-
-        RegExp inputRegExp = RegExp.compile("<input[^<]*?>","g");
-        RegExp selectRegExp = RegExp.compile("<select.*?</select>","g");
-
-
-        String parsedText = srcText;
-        MatchResult inputs;
-        for (RegExp elementRegExp: new RegExp[]{inputRegExp, selectRegExp}) {
-            while ((inputs = elementRegExp.exec(parsedText)) != null) {
-                for (int i = 0; i < inputs.getGroupCount(); i++) {
-                    String inputElement = inputs.getGroup(i);
-                    String oldParsedText = parsedText;
-                    parsedText = parsedText.replace(inputElement, inputReplacer);
-                    MatchResult matchResult;// = gapRegExp.exec(parsedText);
-                    RegExp gapRegExp = RegExp.compile(pattern,"g");
-                    while ((matchResult = gapRegExp.exec(parsedText)) != null) {
-                        for (int j = 0; j < matchResult.getGroupCount(); j++) {
-                            String group = matchResult.getGroup(j);
-                            String wrappedGroup = "<div style=\"display: inline-block;\">" + group + "</div>";
-                            if (parsedText.indexOf(wrappedGroup) != -1 || group.length() == inputReplacer.length()) {
-                                parsedText = oldParsedText;
-                            } else {
-                                String groupWithInput = group.replace(inputReplacer, inputElement);
-                                String replaceText = "<div style='display: inline-block;'>" + groupWithInput + "</div>";
-                                parsedText = parsedText.replace(group, replaceText);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-		return parsedText;
-	};
 
 
 }


### PR DESCRIPTION
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/7828--support--elbaradei-education---rozjechany-layout-w-lekcji-/details?comment=1684308429
Wersja testowa
mauthor-dev: https://test-7828-dot-mauthor-dev.ew.r.appspot.com/
lorepocorporate + kopia lekcji z błędem: https://test-7828-dot-lorepocorporate.appspot.com/present/5227903296602112#2

Dodawanie wrappera dla gap, który miał na celu zapewnienie, aby były wyświetlane w jednej linii z sąsiadującym z nimi tekstem, powodowało problemu w niektórych lekcjach, w związku z tym zostało cofnięte.