### PR TITLE
Fixed Fractions isAttempted issue, re #7825

### DIFF
--- a/addons/Fractions/src/presenter.js
+++ b/addons/Fractions/src/presenter.js
@@ -90,7 +90,6 @@ function AddonFractions_create(){
     };
 
     presenter.isAttempted = function(){
-        presenter.hideAnswers();
         if(!presenter.configuration.isAnswer) {
             return true;
         }

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+2020-11-13 Fixed issue with isAttempted disabling ShowErrors mode in Fractions
+2020-11-12 Removed gap wrapping in Text
 2020-11-02 Added gaps not breaking from text that is directly adjacent to it in Text and Table 
 2020-11-02 Fixed issues with navigation in assessment navigation bar.
 2020-11-02 Fixed issue with opening popup page with YouTube addon


### PR DESCRIPTION
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/realtime_cardwall?ticket=7825
Lekcja testowa: https://test-7825-dot-mauthor-dev.ew.r.appspot.com/embed/5630944843137024

Poprawiłem błąd, przez który wywołanie isAttempted na Fractions powodowało, że addon wychodził z trybu Show Errors (jeśli się w nim znajdował).