### PR TITLE
Added support for randomizeLesson metadata in Assessment Navigation Bar

### DIFF
--- a/addons/Assessments_Navigation_Bar/src/presenter.js
+++ b/addons/Assessments_Navigation_Bar/src/presenter.js
@@ -39,6 +39,8 @@ function AddonAssessments_Navigation_Bar_create(){
     };
 
     presenter.keyboardControllerObject = null;
+    //this field is set based on the metadata. It overrides the defaultOrder property
+    presenter.randomizeLesson = null;
 
     presenter.showErrorMessage = function(message, substitutions) {
         var errorContainer;
@@ -73,6 +75,10 @@ function AddonAssessments_Navigation_Bar_create(){
                 presenter.currentPageIndex = index;
             }
         });
+        var context = controller.getContextMetadata();
+         if (context != null && "randomizeLesson" in context) {
+             presenter.randomizeLesson = context["randomizeLesson"];
+         }
         presenter.commander = controller.getCommands();
         presenter.eventBus = controller.getEventBus();
 
@@ -345,7 +351,11 @@ function AddonAssessments_Navigation_Bar_create(){
     };
 
     presenter.Section.prototype.createPages = function (pages, pagesDescriptions) {
-        var pagesToCreate = presenter.configuration.defaultOrder ? pages : shuffleArray(pages);
+        var keepDefaultOrder = presenter.configuration.defaultOrder;
+        if (presenter.randomizeLesson != null) {
+            keepDefaultOrder = !presenter.randomizeLesson;
+        }
+        var pagesToCreate = keepDefaultOrder ? pages : shuffleArray(pages);
 
         return pagesToCreate.map(function (page, index) {
             return new presenter.Page(page, pagesDescriptions[index], this.name, this.cssClass);

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2020-11-17 Added support for randomizeLesson metadata in Assessment Navigation Bar
 2020-11-02 Added gaps not breaking from text that is directly adjacent to it in Text and Table 
 2020-11-02 Fixed issues with navigation in assessment navigation bar.
 2020-11-02 Fixed issue with opening popup page with YouTube addon


### PR DESCRIPTION
Wersja testowa: https://test-randomize-lesson-dot-mauthor-dev.ew.r.appspot.com/embed/5763789657997312

Na wersji testowej w widoku embed losowo randomizeLesson jest ustawiane na true, false, lub nie jest ustawiane w ogóle.

Dodałem wsparcie dla metadanej  randomizeLesson w Assessment Navigation Bar, która ustala czy kolejność stron będzie losowana, nadpisując tym samym property defaultOrder (jeżeli metadana nie zostanie przekazana, zostanie wykorzystane defaultOrder)