### PR TITLE
Randomize lesson state override

### DIFF
--- a/addons/Assessments_Navigation_Bar/src/presenter.js
+++ b/addons/Assessments_Navigation_Bar/src/presenter.js
@@ -39,8 +39,8 @@ function AddonAssessments_Navigation_Bar_create(){
     };
 
     presenter.keyboardControllerObject = null;
-    //this field is set based on the metadata.
-    //It overrides the defaultOrder property and prevents state import if set
+    //this field is set based on the metadata. It overrides the defaultOrder property
+    // If set to false it prevents state import
     presenter.randomizeLesson = null;
 
     presenter.showErrorMessage = function(message, substitutions) {

--- a/addons/Assessments_Navigation_Bar/src/presenter.js
+++ b/addons/Assessments_Navigation_Bar/src/presenter.js
@@ -1366,8 +1366,8 @@ function AddonAssessments_Navigation_Bar_create(){
         if (state === null || state === "" || state === undefined) {
             return;
         }
-        if (presenter.randomizeLesson !== null) {
-            //Randomize lesson metadata overrides state
+        if (presenter.randomizeLesson === false) {
+            //Randomize lesson == false overrides state
             return;
         }
 

--- a/addons/Assessments_Navigation_Bar/src/presenter.js
+++ b/addons/Assessments_Navigation_Bar/src/presenter.js
@@ -39,7 +39,8 @@ function AddonAssessments_Navigation_Bar_create(){
     };
 
     presenter.keyboardControllerObject = null;
-    //this field is set based on the metadata. It overrides the defaultOrder property
+    //this field is set based on the metadata.
+    //It overrides the defaultOrder property and prevents state import if set
     presenter.randomizeLesson = null;
 
     presenter.showErrorMessage = function(message, substitutions) {
@@ -1363,6 +1364,10 @@ function AddonAssessments_Navigation_Bar_create(){
 
     presenter.setState = function(state){
         if (state === null || state === "" || state === undefined) {
+            return;
+        }
+        if (presenter.randomizeLesson !== null) {
+            //Randomize lesson metadata overrides state
             return;
         }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2020-11-20 Changed randomizeLesson in Assessment Navigation Bar to override addon state
 2020-11-17 Added support for randomizeLesson metadata in Assessment Navigation Bar
 2020-11-02 Added gaps not breaking from text that is directly adjacent to it in Text and Table 
 2020-11-02 Fixed issues with navigation in assessment navigation bar.


### PR DESCRIPTION
Lekcja testowa: https://test-randomize-lesson-state-override-dot-mauthor-dev.ew.r.appspot.com/embed/5763789657997312

Zmodyfikowałem Assessment Navigation Bar, żeby ustawienie randomizeLesson powodowało zablokowanie ustawiania stanu.