### PR TITLE
Added support for assessementUser metadata in Assessment Navigation Bar

### DIFF
--- a/addons/Assessments_Navigation_Bar/src/presenter.js
+++ b/addons/Assessments_Navigation_Bar/src/presenter.js
@@ -43,6 +43,13 @@ function AddonAssessments_Navigation_Bar_create(){
     // If set to false it prevents state import
     presenter.randomizeLesson = null;
 
+    presenter.ASSESSMENT_USER_TYPES = {
+        NONE: 0,
+        TEACHER: 1,
+        STUDENT: 2,
+    }
+    presenter.assessmentUser = presenter.ASSESSMENT_USER_TYPES.NONE;
+
     presenter.showErrorMessage = function(message, substitutions) {
         var errorContainer;
         if(typeof(substitutions) == 'undefined') {
@@ -77,8 +84,17 @@ function AddonAssessments_Navigation_Bar_create(){
             }
         });
         var context = controller.getContextMetadata();
-         if (context != null && "randomizeLesson" in context) {
-             presenter.randomizeLesson = context["randomizeLesson"];
+         if (context != null) {
+            if ("randomizeLesson" in context) {
+                 presenter.randomizeLesson = context["randomizeLesson"];
+            }
+            if ("assessmentUser" in context) {
+               if (context["assessmentUser"] == "teacher") {
+                    presenter.assessmentUser = presenter.ASSESSMENT_USER_TYPES.TEACHER;
+               } else if (context["assessmentUser"] == "student") {
+                    presenter.assessmentUser = presenter.ASSESSMENT_USER_TYPES.STUDENT;
+               }
+            }
          }
         presenter.commander = controller.getCommands();
         presenter.eventBus = controller.getEventBus();
@@ -353,14 +369,24 @@ function AddonAssessments_Navigation_Bar_create(){
 
     presenter.Section.prototype.createPages = function (pages, pagesDescriptions) {
         var keepDefaultOrder = presenter.configuration.defaultOrder;
-        if (presenter.randomizeLesson != null) {
+        if (presenter.assessmentUser != presenter.ASSESSMENT_USER_TYPES.NONE) {
+            if (presenter.assessmentUser == presenter.ASSESSMENT_USER_TYPES.TEACHER) {
+                keepDefaultOrder = true;
+            } else {
+                // presenter.assessmentUser set to student
+                keepDefaultOrder = false;
+            }
+        } else if (presenter.randomizeLesson != null) {
             keepDefaultOrder = !presenter.randomizeLesson;
         }
         var pagesToCreate = keepDefaultOrder ? pages : shuffleArray(pages);
 
         return pagesToCreate.map(function (page, index) {
+            if (page == -1) return null;
             return new presenter.Page(page, pagesDescriptions[index], this.name, this.cssClass);
-        }, this);
+        }, this).filter(function(page) {
+            return page != null;
+        });
     };
 
     presenter.Sections = function (sections) {
@@ -488,10 +514,21 @@ function AddonAssessments_Navigation_Bar_create(){
     presenter.filterSectionsWithTooManyPages = function(sections) {
         var mapping = presenter.playerController.getPagesMapping();
 
-        for (var i = 0; i < sections.length; i++) {
-            sections[i].pages = sections[i].pages.filter(function (page) {
-                return mapping[page] >= 0;
-            });
+        if (presenter.assessmentUser == presenter.ASSESSMENT_USER_TYPES.TEACHER) {
+            for (var i = 0; i < sections.length; i++) {
+                for(var j = 0; j < sections[i].pages.length; j++) {
+                    var page = sections[i].pages[j];
+                    if (mapping[page] == -1) {
+                        sections[i].pages[j] = -1;
+                    }
+                }
+            }
+        } else {
+            for (var i = 0; i < sections.length; i++) {
+                sections[i].pages = sections[i].pages.filter(function (page) {
+                    return mapping[page] >= 0;
+                });
+            }
         }
 
         sections = sections.filter(function(section) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2020-11-25 Added support for assessmentUser metadata in Assessment Navigation Bar
 2020-11-20 Changed randomizeLesson in Assessment Navigation Bar to override addon state
 2020-11-19 Add new property for SingleStateButton which allows clicking in error mode.
 2020-11-17 Added support for randomizeLesson metadata in Assessment Navigation Bar


### PR DESCRIPTION
Lekcja testowa: https://test-anb-assessment-user-dot-mauthor-dev.ew.r.appspot.com/embed/5754183158333440

Przekazanie w metadanych pola assessmentUser da następujący efekt:

- "teacher" - strony wyświetlają się w domyślnej kolejności, a nazwy przycisków nadawane są z uwzględnieniem stron wyłączonych przez setPages.
- "student" - kolejność stron jest losowana, a nazwy przycisków nadawane po kolei.

Przykładowo, jeśli lekcja ma pięć stron, strona 2 i 4 są wyłączone, a property sections zostanie ustawione na "1-5;;1,2,3,4,5", to ANB powinien wyświetlić następujące wartości

- "teacher" - 1,3,5
- "student" - 1,2,3

Dla ułatwienia testowania widok embed został zmodyfikowany w następujący sposób:

przed załadowaniem lekcji w widoku embed wykonywane są dwie metody:
1. player.setPages('0,2,4');
2. player.setContextMetadata({"assessmentUser":assessmentUserType}), gdzie assessmentUserType jest losowane ze zbioru ["teacher","student"]. Wartość, która została wylosowana jest podana w konsoli.