### PR TITLE
Fixing issue with not opening lessons on mobile RE #5397

### DIFF
--- a/src/main/java/com/lorepo/icplayer/client/model/Content.java
+++ b/src/main/java/com/lorepo/icplayer/client/model/Content.java
@@ -207,7 +207,9 @@ public class Content implements IContentBuilder, IContent {
 		// Addons
 		xml += "<addons>";
 		for(AddonDescriptor descriptor : addonDescriptors.values()){
-			xml += "<addon-descriptor addonId='"+descriptor.getAddonId()+"' href='"+descriptor.getHref()+"'/>";
+		    if (descriptor.getAddonId() != "null") {
+			    xml += "<addon-descriptor addonId='"+descriptor.getAddonId()+"' href='"+descriptor.getHref()+"'/>";
+			}
 		}
 		xml += 	"</addons>";
 

--- a/src/main/java/com/lorepo/icplayer/client/model/Content.java
+++ b/src/main/java/com/lorepo/icplayer/client/model/Content.java
@@ -207,7 +207,7 @@ public class Content implements IContentBuilder, IContent {
 		// Addons
 		xml += "<addons>";
 		for(AddonDescriptor descriptor : addonDescriptors.values()){
-		    if (descriptor.getAddonId() != "null") {
+		    if (descriptor.getAddonId() != null && !descriptor.getAddonId().equals("null")) {
 			    xml += "<addon-descriptor addonId='"+descriptor.getAddonId()+"' href='"+descriptor.getHref()+"'/>";
 			}
 		}

--- a/src/main/java/com/lorepo/icplayer/client/xml/content/parsers/ContentParserBase.java
+++ b/src/main/java/com/lorepo/icplayer/client/xml/content/parsers/ContentParserBase.java
@@ -134,7 +134,7 @@ public abstract class ContentParserBase implements IContentParser {
 		for(int i = 0; i < descriptorNodes.getLength(); i++){
 			Element node = (Element)descriptorNodes.item(i);
 			String addonId = node.getAttribute("addonId");
-			if (addonId != "null") {
+			if (!addonId.equals("null")) {
                 String href = StringUtils.unescapeXML(node.getAttribute("href"));
                 addonDescriptors.put(addonId, new AddonDescriptor(addonId, href));
             }

--- a/src/main/java/com/lorepo/icplayer/client/xml/content/parsers/ContentParserBase.java
+++ b/src/main/java/com/lorepo/icplayer/client/xml/content/parsers/ContentParserBase.java
@@ -134,8 +134,10 @@ public abstract class ContentParserBase implements IContentParser {
 		for(int i = 0; i < descriptorNodes.getLength(); i++){
 			Element node = (Element)descriptorNodes.item(i);
 			String addonId = node.getAttribute("addonId");
-			String href = StringUtils.unescapeXML(node.getAttribute("href"));
-			addonDescriptors.put(addonId, new AddonDescriptor(addonId, href));
+			if (addonId != "null") {
+                String href = StringUtils.unescapeXML(node.getAttribute("href"));
+                addonDescriptors.put(addonId, new AddonDescriptor(addonId, href));
+            }
 		}
 
 		return addonDescriptors;


### PR DESCRIPTION
Do plików dodano zabezpieczenie przed pustym addonem.
Ticket:
https://learneticsa.assembla.com/spaces/mcourser/tickets/5397--pearson--niewczytuj%C4%85cy-si%C4%99-test-na-telefonie-z-androidem/details#
Wersja testowa:
https://test-5397-dot-mcourser-dev.appspot.com