### PR TITLE
Fixed Connection stretching and add draggable gap support in print, re #5492

### DIFF
--- a/addons/Connection/src/presenter.js
+++ b/addons/Connection/src/presenter.js
@@ -2048,7 +2048,6 @@ function AddonConnection_create() {
         $root.attr('id', model.ID);
         $root.addClass('printable_addon_Connection');
         $root.css("max-width", model["Width"]+"px");
-        $root.css("min-height", model["Height"]+"px");
         $root.html('<table class="connectionContainer">' +
             '    <tr>' +
             '        <td class="connectionLeftColumn">' +
@@ -2094,6 +2093,10 @@ function AddonConnection_create() {
                 }
             }
         }
+
+        var height = getPrintableTableHeight($root);
+        $root.css("height", height+"px");
+
         if (connected.length > 0) {
             $root.css('visibility', 'hidden');
             $('body').append($root);
@@ -2111,6 +2114,30 @@ function AddonConnection_create() {
 
     return presenter;
 }
+
+function getPrintableTableHeight($table) {
+        var $outerLessonWrapper = $("<div></div>");
+        $outerLessonWrapper.css("position", "absolute");
+        $outerLessonWrapper.css("visibility", "hidden");
+        $outerLessonWrapper.addClass("printable_lesson");
+
+        var $outerPageWrapper = $("<div></div>");
+        $outerPageWrapper.addClass("printable_page");
+        $outerLessonWrapper.append($outerPageWrapper);
+
+        var $outerModuleWrapper = $("<div></div>");
+        $outerModuleWrapper.addClass("printable_module");
+        $outerModuleWrapper.addClass("printable_addon_Connection");
+        $outerPageWrapper.append($outerModuleWrapper);
+
+		$outerModuleWrapper.append($table);
+
+		$("body").append($outerLessonWrapper);
+		var height = $table[0].getBoundingClientRect().height;
+		$outerLessonWrapper.detach();
+		$table.detach();
+		return height;
+    }
 
 AddonConnection_create.__supported_player_options__ = {
     resetInterfaceVersion: 2

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2020-12-17 Fixed stretching of Connection addon and added draggable gap support in Text for print
 2020-12-03 Fixxed issue with font size of printable lessons
 2020-11-27 Added playback rate control to the Audio addon
 2020-11-26 Fixed issue with assessmentUser==teacher being overrriden by student's state

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextPrintable.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextPrintable.java
@@ -1,6 +1,7 @@
 package com.lorepo.icplayer.client.module.text;
 
 import java.util.Iterator;
+import java.util.ArrayList;
 
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NodeList;
@@ -39,10 +40,26 @@ public class TextPrintable {
 	
 	private String makePrintableInput(String parsedText, boolean showAnswers) {
 		HTML html = new HTML(parsedText);
-		
-		NodeList<Element> inputs = html.getElement().getElementsByTagName("input");
-		for (int i = 0; i < inputs.getLength(); i++) {
-			Element input = inputs.getItem(i);
+
+		ArrayList<Element> gaps = new ArrayList<Element>();
+
+		if (this.model.hasDraggableGaps()) {
+			NodeList<Element> spans = html.getElement().getElementsByTagName("span");
+			for (int i = 0; i < spans.getLength(); i++) {
+				Element span = spans.getItem(i);
+				if (span.getClassName().indexOf("ic_draggableGap") != -1) {
+					gaps.add(span);
+				}
+			}
+		} else {
+			NodeList<Element> inputs = html.getElement().getElementsByTagName("input");
+			for (int i = 0; i < inputs.getLength(); i++) {
+				gaps.add(inputs.getItem(i));
+			}
+		}
+
+		for (int i = 0; i < gaps.size(); i++) {
+			Element input = gaps.get(i);
 			String oldValue = input.getString();
 			Element span = DOM.createSpan();
 			


### PR DESCRIPTION
1) Czasem addon Connection przy drukowaniu "rozciągał się" w pionie na całą stronę. Problem nie powinien już występować.
2) Dodałem wsparcie dla dragowalnych gap modułu Text w wydruku w trybie showAnswers.