### PR TITLE
New property open lesson on current tab in cross lesson addon

### DIFF
--- a/addons/Cross_Lesson/src/addon.xml
+++ b/addons/Cross_Lesson/src/addon.xml
@@ -8,5 +8,6 @@
 		<property name='CourseID' nameLabel="Cross_Lesson_property_course_id" type='string' />
 		<property name='Page' nameLabel="Cross_Lesson_property_Page" type='string' />
 		<property name='Type' nameLabel="Cross_Lesson_property_type" type='{lesson, ebook}' />
+		<property name="OpenLessonInCurrentTab" nameLabel="Cross_Lesson_property_open_in_current_tab" type="boolean"/>
 	</model>
 </addon>

--- a/addons/Cross_Lesson/src/presenter.js
+++ b/addons/Cross_Lesson/src/presenter.js
@@ -23,7 +23,8 @@ function AddonCross_Lesson_create(){
     };
 
     function presenterLogic(view, model, preview) {
-        presenter.configuration = presenter.validateModel(model);
+        var upgradedModel = presenter.upgradeModel(model);
+        presenter.configuration = presenter.validateModel(upgradedModel);
 
         if (presenter.configuration.isError) {
             presenter.createErrorView(view, presenter.configuration.errorCode);
@@ -54,7 +55,8 @@ function AddonCross_Lesson_create(){
             courseID: validatedCourseId.value,
             type: validatedType.value,
             page: model['Page'],
-            image: model['Image']
+            image: model['Image'],
+            openLessonInCurrentTab: ModelValidationUtils.validateBoolean(model.OpenLessonInCurrentTab)
         }
     };
 
@@ -137,7 +139,8 @@ function AddonCross_Lesson_create(){
         if (presenter.playerController) {
             var data = {
                 lessonID: presenter.configuration.lessonID,
-                type: presenter.configuration.type
+                type: presenter.configuration.type,
+                openLessonInCurrentTab: presenter.configuration.openLessonInCurrentTab
             };
             if (presenter.configuration.page) {
                 data.page = presenter.configuration.page;
@@ -182,6 +185,22 @@ function AddonCross_Lesson_create(){
         };
 
         Commands.dispatch(commands, name, [], presenter);
+    };
+
+    presenter.upgradeOpenLessonInCurrentTab = function (model) {
+        var upgradedModel = {};
+        $.extend(true, upgradedModel, model); // Deep copy of model object
+
+        if (!upgradedModel["OpenLessonInCurrentTab"]) {
+            upgradedModel["OpenLessonInCurrentTab"] = "False";
+        }
+
+        return upgradedModel;
+    };
+
+    presenter.upgradeModel = function AddonCross_Lesson_upgradeModel (model) {
+        var upgradedModel = presenter.upgradeOpenLessonInCurrentTab(model);
+        return upgradedModel;
     };
 
     return presenter;

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/bl/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/bl/dictionary.js
@@ -2060,6 +2060,7 @@ var ice_dictionary_bl = {
 	"Cross_Lesson_property_course_id": "Course id",
 	"Cross_Lesson_property_page": "Page",
 	"Cross_Lesson_property_type": "Type",
+	"Cross_Lesson_property_open_in_current_tab": "Open in current tab",
 	"printable_name_label": "Printable",
 	"printable_block_split_label": "Block splitting in print",
 	"printable_is_section": "is section",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/com/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/com/dictionary.js
@@ -2066,6 +2066,7 @@ var ice_dictionary_en = {
 	"Cross_Lesson_property_course_id": "Course id",
 	"Cross_Lesson_property_page": "Page",
 	"Cross_Lesson_property_type": "Type",
+	"Cross_Lesson_property_open_in_current_tab": "Open in current tab",
 	"printable_name_label": "Printable",
 	"printable_block_split_label": "Block splitting in print",
 	"printable_is_section": "is section",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/fr/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/fr/dictionary.js
@@ -2045,6 +2045,7 @@ var ice_dictionary_fr = {
 	"Cross_Lesson_property_course_id": "Course id",
 	"Cross_Lesson_property_page": "Page",
 	"Cross_Lesson_property_type": "Type",
+    "Cross_Lesson_property_open_in_current_tab": "Open in current tab",
 	"printable_name_label": "Printable",
 	"printable_block_split_label": "Block splitting in print",
 	"printable_is_section": "is section",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/mx/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/mx/dictionary.js
@@ -2045,6 +2045,7 @@ var ice_dictionary_mx = {
 	"Cross_Lesson_property_course_id": "Course id",
 	"Cross_Lesson_property_page": "Page",
 	"Cross_Lesson_property_type": "Type",
+	"Cross_Lesson_property_open_in_current_tab": "Open in current tab",
 	"printable_name_label": "Printable",
 	"printable_block_split_label": "Block splitting in print",
 	"printable_is_section": "is section",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/pl/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/pl/dictionary.js
@@ -2044,6 +2044,7 @@ var ice_dictionary_pl = {
 	"Cross_Lesson_property_course_id": "Course id",
 	"Cross_Lesson_property_page": "Page",
 	"Cross_Lesson_property_type": "Type",
+	"Cross_Lesson_property_open_in_current_tab": "Open in current tab",
 	"printable_name_label": "Printable",
 	"printable_block_split_label": "Block splitting in print",
 	"printable_is_section": "is section",


### PR DESCRIPTION
Dodane zostało nowe property w adonie Cross Lesson pozwalające na otwieranie lekcji w tym samym oknie

Wersja testowa:
https://test-7851-dot-mauthor-dev.ew.r.appspot.com/
Lekcja testowa:
https://test-7851-dot-mauthor-dev.ew.r.appspot.com/embed/5992475392999424
Ticket:
https://learneticsa.assembla.com/spaces/lorepo/tickets/realtime_cardwall?ticket=7851

Testowanie:

1. Dodać addon cross lesson
2. Wypełnić danymi i zaznaczyć/odznaczyć nowe property "Open in current tab"
3. wykonać w konsoli komendę:
```player.onExternalEvent(function(eventname,data){console.log(data);});```
