### PR TITLE
Removed display of placeholder text after show and hide (#7878)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2021-03-10 Removed display of placeholder text after show and hide
 2021-02-24 Add Text property to Multiaudio addon
 2021-02-22 Added Enable in error checking mode property to Media Recorder
 2021-02-11 Fixed show answers and check sending unneeded events

--- a/src/main/java/com/lorepo/icplayer/client/module/text/GapWidget.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/GapWidget.java
@@ -45,7 +45,7 @@ public class GapWidget extends TextBox implements TextElementDisplay {
 		 * When gap is rerendered by MathJax then will lost connection to DOM element (handlers doesn't work). 
 		 * In this case we need to drop old gap, find new one and set listeners to him.
 		 */
-		String value = this.getTextValue();
+		String value = super.getText();
 		boolean isDisabled = this.isDisabled();
 		this.removeHandlers();
 		this.onDetach();


### PR DESCRIPTION
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/7878--support--nie-dzia%C5%82a-clear-placeholder-on-focus-w-addonie-niewidocznym-na/details
Wersja testowa: https://test-7878-dot-mauthor-dev.ew.r.appspot.com
Lekcja z wersją testową: https://test-7878-dot-mauthor-dev.ew.r.appspot.com/embed/5442425130582016

Zmiana została wprowadzona w tym miejscu aby zapewnić kompatybilność wsteczną z zadaniem z ticketu: 
https://learneticsa.assembla.com/spaces/lorepo/tickets/6667--support--filledgap-nie-ocenia-odpowiedzi--kt%C3%B3re-maj%C4%85-tak%C4%85-sam%C4%85/details