### PR TITLE
Fix for stretched table in print, re #5718

### DIFF
--- a/addons/Table/src/style.css
+++ b/addons/Table/src/style.css
@@ -36,7 +36,7 @@
 }
 
 .printable_addon_Table .table-addon-wrapper {
-    height: auto;
+    height: fit-content;
 }
 
 .printable_addon_Table tbody tr:first-child {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2021-03-15 Fixed table stretching in print
 2021-03-15 Added show and hide for Crossword
 2021-03-15 Fixed numeric TextBox for iPad
 2021-03-15 Fixed Test Puzzle error on firefox when entering a page in show errors mode


### PR DESCRIPTION
Poprawka rozwiązuje problem rozciągania addonu table na całą wysokość strony w niektórych lekcjach.
Ticket: https://learneticsa.assembla.com/spaces/mcourser/tickets/5718--pearson--pr%C3%B3bny-egzamin-%C3%B3smoklasisty-dla-klasy-8-%E2%80%93-problem-w-/details
Wersja testowa: https://mcourser-dev.appspot.com/ (test-5718 ustawiony na default na potrzeby testowania)

Test
teacherTEST0052::t
1) Wejdź w tworzenie testu do druku (Assessments -> Tests -> Printable tests -> Create printable test)
2) Utwórz test z lekcji "Próbny egzamin ósmoklasisty dla klasy 8" w kursie "printable_kurs"
3) Sprawdź, czy w wygenerowanym pdfie żadna z tabelek nie jest niepotrzebnie rozciągnięta na całą wysokość strony.

Uwaga - do testowania wersja test-5718 musi otrzymywać defaultowy traffic mcourser-dev! Jeśli nadal doświadczasz błędu, upewnij się, że wersja nie została zmieniona.