### PR TITLE
Implementation of audio files export. #5311

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2021-03-29 Implementation of audio files export
 2021-03-26 Add new addon Scoreboard
 2021-03-25 Added scriptable button to IWB Toolbar
 2021-03-25 Fixed issue with images breaking pagination in print

--- a/src/main/java/com/lorepo/icplayer/client/content/services/AssetsService.java
+++ b/src/main/java/com/lorepo/icplayer/client/content/services/AssetsService.java
@@ -1,11 +1,16 @@
 package com.lorepo.icplayer.client.content.services;
 
 import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+
 import com.lorepo.icplayer.client.model.IAsset;
 import com.lorepo.icplayer.client.module.api.player.IAssetsService;
 import com.lorepo.icplayer.client.module.api.player.IContent;
+import com.google.gwt.core.client.JavaScriptObject;
+import com.lorepo.icf.utils.JavaScriptUtils;
 
-public class AssetsService implements IAssetsService{
+public class AssetsService implements IAssetsService {
 	
 	private final List<IAsset> assets;
 	
@@ -25,5 +30,24 @@ public class AssetsService implements IAssetsService{
 		}
 
 		return contentType;
+	}
+
+	@Override
+	public List<JavaScriptObject> getAssetsAsJS() {
+		List<JavaScriptObject> assetsList = new ArrayList<JavaScriptObject>();
+		for (IAsset asset : assets) {
+			assetsList.add(this.mapFromAsset(asset));
+		}
+		return assetsList;
+	}
+
+	public JavaScriptObject mapFromAsset(IAsset asset) {
+		HashMap<String, String> map = new HashMap<String, String>();
+
+		map.put("fileName", asset.getFileName());
+		map.put("type", asset.getContentType());
+		map.put("href", asset.getHref());
+
+		return JavaScriptUtils.createHashMap(map);
 	}
 }

--- a/src/main/java/com/lorepo/icplayer/client/content/services/JavaScriptPlayerServices.java
+++ b/src/main/java/com/lorepo/icplayer/client/content/services/JavaScriptPlayerServices.java
@@ -55,6 +55,16 @@ public class JavaScriptPlayerServices {
 		return jsObject;
 	}
 
+	public JsArray<JavaScriptObject> getAssetsAsJS() {
+		List<JavaScriptObject> assetsList = playerServices.getAssetsService().getAssetsAsJS();
+		JsArray<JavaScriptObject> jsArray = (JsArray<JavaScriptObject>) JavaScriptObject.createArray();
+
+		for (JavaScriptObject object : assetsList){
+			jsArray.push(object);
+		}
+		return jsArray;
+	}
+
 	private native JavaScriptObject initJSObject(JavaScriptPlayerServices x) /*-{
 
 		var playerServices = function() {};
@@ -352,6 +362,10 @@ public class JavaScriptPlayerServices {
 
 			assets.getContentType = function(href) {
 				return x.@com.lorepo.icplayer.client.content.services.JavaScriptPlayerServices::getContentType(Ljava/lang/String;)(href);
+			};
+
+			assets.getAssetsAsJS = function() {
+				return x.@com.lorepo.icplayer.client.content.services.JavaScriptPlayerServices::getAssetsAsJS()();
 			};
 
 			return assets;

--- a/src/main/java/com/lorepo/icplayer/client/module/api/player/IAssetsService.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/api/player/IAssetsService.java
@@ -1,5 +1,8 @@
 package com.lorepo.icplayer.client.module.api.player;
+import java.util.List;
+import com.google.gwt.core.client.JavaScriptObject;
 
 public interface IAssetsService {
 	public String getContentType (String href);
+	public List<JavaScriptObject> getAssetsAsJS();
 }


### PR DESCRIPTION
Wersja testowa: https://test-5311-dot-mcourser-dev.appspot.com/home

W celu przetestowania zaimplementowanej funkcjonalności należy poprzez panel assessment utworzyć nowy printable test. Następnie, po wygenerowaniu się testu, należy pobrać paczkę. Paczka powinna zawierać wszystkie pliki audio danej lekcji.