### PR TITLE
Fixed width and height for ruler in IWB Toolbar

### DIFF
--- a/addons/IWB_Toolbar/src/presenter.js
+++ b/addons/IWB_Toolbar/src/presenter.js
@@ -1762,8 +1762,8 @@ function AddonIWB_Toolbar_create() {
         var stage = new Kinetic.Stage({
             container: $mask[0],
             visible: true,
-            width: presenter.$pagePanel.width(),
-            height: presenter.$pagePanel.height()
+            width: $mask.width(),
+            height: $mask.height()
         });
 
         var layer = new Kinetic.Layer();

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2021-05-28 Fix width and height space for floating images in IWBToolbar
 2021-05-25 Added support for printable state in ordering
 2021-05-24 Added support for printable state in Choice addon
 2021-05-21 Added support for printable state in text identification


### PR DESCRIPTION
Podczas używania linijki lub innych obrazków w IWBPhoto, źle była brana szerokość i wysokośc okienka.
Jeżeli dane strony miały rózne wielkości, to po przejściu ze strony jednej na drugą i użyciu linijki nie można było nią jeździć po całej stronie.
Przykład:
https://mauthor-dev.ew.r.appspot.com/embed/5369298144985088
1. Wchodzimy na stronę pierwszą
2. Przechodzimy na stronę drugą
3. Rozszerzamy IWBToolbar i wybieramy linijkę
4. Próbujemy przesunąc ją na sam dół strony, ale widzimy w połowie już znika i nie da się niżej przesunąć.

Błąd ten nie występuje po poprawce:
https://test-7992-dot-mauthor-dev.ew.r.appspot.com/embed/5369298144985088