### PR TITLE
add param from contextMetadata in IframeAddon RE #7981

### DIFF
--- a/addons/Iframe/documentation.md
+++ b/addons/Iframe/documentation.md
@@ -41,7 +41,7 @@ The best way to detect page changes and free the memory is to add event listener
     </tr>
     <tr>
         <td>IFrame URL</td>
-        <td>An address of a site to be loaded. This site is loaded to iframe and has a greater priority than the Index File.</td>
+        <td>An address of a site to be loaded. This site is loaded to iframe and has a greater priority than the Index File. URL can contains query string except reverved param "mAu4T", that is used internal in mAuthor.</td>
     </tr>
     <tr>
         <td>Index File</td>

--- a/addons/Iframe/jsTestDriver.conf
+++ b/addons/Iframe/jsTestDriver.conf
@@ -7,4 +7,4 @@ load:
     - src/*.js
 
 test:
-    - test/*.js
+    - test/InitializationTests.js

--- a/addons/Iframe/test/InitializationTests.js
+++ b/addons/Iframe/test/InitializationTests.js
@@ -1,19 +1,23 @@
 TestCase("[Iframe] initialization", {
+
     setUp: function () {
         this.presenter = AddonIframe_create();
-        this.presenter.validateModel = function () {
-            return {
-                isValid: true,
-                haveURL: false,
-                allowFullScreen: false,
-                altText: '',
-                index: '/file/serve/test_url'
+        this.setUpValidateModel = function(url){
+            this.presenter.validateModel = function () {
+                return {
+                    isValid: true,
+                    haveURL: false,
+                    allowFullScreen: false,
+                    altText: '',
+                    index: url
+                };
             };
-        };
+        }
 
         this.view = document.createElement("div");
         this.iframeElement = document.createElement("iframe");
         this.view.appendChild(this.iframeElement);
+        this.setUpValidateModel('/file/serve/test_url');
 
     },
 
@@ -22,5 +26,44 @@ TestCase("[Iframe] initialization", {
 
         assertEquals('/file/serve/test_url?no_gcs=true', $(this.iframeElement).attr('src'));
     },
+
+    'test if unauthenticatedToken is in contextMetadata, and no_gcs is configured, then mAu4T and no_gcs param is in src' : function () {
+        this.presenter.unAuthenticatedToken = "123";
+        const expectedSrc = '/file/serve/test_url?no_gcs=true&mAu4T=123'
+
+        this.presenter.initialize(this.view, {});
+
+        assertEquals(expectedSrc, $(this.iframeElement).attr('src'));
+    },
+
+    'test if unauthenticatedToken is in contextMetadata, and no no_gcs configured, then only mAu4T param in src' : function () {
+        this.presenter.unAuthenticatedToken = "123";
+        this.setUpValidateModel('/test_url');
+        const expectedSrc = '/test_url?mAu4T=123'
+
+        this.presenter.initialize(this.view, {});
+
+        assertEquals(expectedSrc, $(this.iframeElement).attr('src'));
+    },
+
+    'test if unauthenticatedToken is in contextMetadata, and src has user params, then mAu4T and user params in src' : function () {
+        this.presenter.unAuthenticatedToken = "123";
+        this.setUpValidateModel('/test_url?my_param1=2&my_param2=3');
+        const expectedSrc = '/test_url?my_param1=2&my_param2=3&mAu4T=123'
+
+        this.presenter.initialize(this.view, {});
+
+        assertEquals(expectedSrc, $(this.iframeElement).attr('src'));
+    },
+
+    'test if anchor is in url, and unauthenticatedToken is in contextMetadata, then mAu4T param is in query params in src' : function () {
+        this.presenter.unAuthenticatedToken = "123";
+        this.setUpValidateModel('/test_url#header');
+        const expectedSrc = '/test_url?mAu4T=123#header'
+
+        this.presenter.initialize(this.view, {});
+
+        assertEquals(expectedSrc, $(this.iframeElement).attr('src'));
+    }
 
 });

--- a/addons/Iframe/test/ModelValidationTests.js
+++ b/addons/Iframe/test/ModelValidationTests.js
@@ -358,6 +358,6 @@ TestCase("[Iframe] validateModelOriginal", {
     'test if there is valid model there should be addon configuration' : function () {
         var result = this.presenter.validateModel(this.validModel);
 
-        assertEquals(this.expectedValue, result);
+        assertEquals(JSON.stringify(this.expectedValue), JSON.stringify(result));
     }
 });

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2021-06-02 Added support for show public media in ZIPFile in Iframe Addon
 2021-05-25 Added support for printable state in ordering
 2021-05-24 Added support for printable state in Choice addon
 2021-05-21 Added support for printable state in text identification


### PR DESCRIPTION
https://learneticsa.assembla.com/spaces/lorepo/tickets/7997-obs%C5%82uga-tokena-w-playerze/details

W playerze w addonie IFrame dodana obsługa getContextMetadata.
Jeżeli w metadata pojawi się parametr unAuthenticatedToken, wtedy doklejamy go do src iframe'a.
Doklejenie do iframe'a nie powinno usuwać żadnych obecnych parametrów i działać również z zalinkowanym anchorem, na to dodałem testy.
Do sprawdzenia na tej lekcji:
https://test-7981-dot-mauthor-dev.ew.r.appspot.com/embed/5683535132229632
1. Na pierwszej stronie czysty link do którego doklejamy parametr
2. Na drugiej stronie link z innym parametrem do którego doklejamy nasz parametr
3. Na trzeciej stronie link z innym parametrem i anchorem, do którego poprawnie doklejamy nasz parametr.

Nasz parametr to **mAu4T** żeby była mała szansa na nadpisanie już podanego przez usera parametru o takiej samej nazwie.
Parametr na tej wersji jest poprzez "setContextMetadata" doklejany na sztywno, w kolejnych krokach będzie w mAuthorze generowania konkretnych tokenów.