### PR TITLE
Fix too long event handling blocking redraw in coloring, re #7940

### DIFF
--- a/addons/Coloring/src/presenter.js
+++ b/addons/Coloring/src/presenter.js
@@ -257,7 +257,10 @@ function AddonColoring_create(){
             }
 
             if(!presenter.configuration.colorCorrect){
-                presenter.userInteractionSendingEvent(getClickedArea(presenter.click));
+                setTimeout(function(){
+                    // Without timeout there are issues on Firefox if event handling takes too long
+                    presenter.userInteractionSendingEvent(getClickedArea(presenter.click));
+                }, 0);
             }
 
             if (!presenter.isAlreadyInColorsThatCanBeFilled(presenter.configuration.currentFillingColor)) {
@@ -266,7 +269,10 @@ function AddonColoring_create(){
         }
         if(presenter.configuration.colorCorrect){
             presenter.checkIfColoredCorrectly();
-            presenter.sendEvent([presenter.click.x, presenter.click.y], presenter.configuration.isErase ? 0 : 1, 1);
+            setTimeout(function(){
+                // Without timeout there are issues on Firefox if event handling takes too long
+                presenter.sendEvent([presenter.click.x, presenter.click.y], presenter.configuration.isErase ? 0 : 1, 1);
+            }, 0);
         }
     };
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2021-06-09 Fixed too long event handling blocking redrawing of the Coloring addon on Firefox
 2021-06-07 Added support for printable state in Text addon
 2021-06-07 Added support for printable state in Connection
 2021-05-28 Fix width and height space for floating images in IWBToolbar

--- a/src/main/java/com/lorepo/icplayer/client/utils/MathJax.java
+++ b/src/main/java/com/lorepo/icplayer/client/utils/MathJax.java
@@ -53,7 +53,9 @@ public class MathJax {
 		// https://github.com/mathjax/MathJax-docs/wiki/How-to-stop-listening-or-un-register-from-a-messagehook
 		setTimeout(
 			function removeHook() {
-				$wnd.MathJax.Hub.signal.hooks["End Process"].Remove(hook);
+				if ($wnd.MathJax) {
+					$wnd.MathJax.Hub.signal.hooks["End Process"].Remove(hook);
+				}
 			},
 			0
 		);


### PR DESCRIPTION
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/7940--aga--coloring-na-firefox---op%C3%B3%C5%BAnienie-przy-kolorowaniu/details?comment=1690405715
Lekcja testowa: https://test-7940-dot-mauthor-dev.ew.r.appspot.com/embed/5026055297433600#9