### PR TITLE
hotfix null workWith in GradualShowAnswer RE #8017

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2021-06-17 Hotfix GradualShowAnswer respect null argument (for usage in private addons)
 2021-06-14 Fixed TTS failing when text is too long
 2021-06-09 Fixed too long event handling blocking redrawing of the Coloring addon on Firefox
 2021-06-07 Fix eKeyboard getting triggered by clicking on the audio gap

--- a/src/main/java/com/lorepo/icplayer/client/content/services/GradualShowAnswersService.java
+++ b/src/main/java/com/lorepo/icplayer/client/content/services/GradualShowAnswersService.java
@@ -42,9 +42,11 @@ public class GradualShowAnswersService implements IGradualShowAnswersService {
     @Override
     public boolean showNext(String worksWith) {
         List<String> worksWithList = new ArrayList<String>();
-        for(String workWith: worksWith.split("\n")){
-            if(!workWith.isEmpty()) {
-                worksWithList.add(workWith.trim());
+        if(worksWith != null) {
+            for (String workWith : worksWith.split("\n")) {
+                if (!workWith.isEmpty()) {
+                    worksWithList.add(workWith.trim());
+                }
             }
         }
 

--- a/src/test/java/com/lorepo/icplayer/client/content/service/GradualShowAnswersServiceTestCase.java
+++ b/src/test/java/com/lorepo/icplayer/client/content/service/GradualShowAnswersServiceTestCase.java
@@ -117,6 +117,13 @@ public class GradualShowAnswersServiceTestCase {
         this.thenEventNotFired();
     }
 
+    @Test
+    public void testCallFirstPresenterIfNullIsGivenAsWorkWith(){
+        this.givenWorkWith(null);
+        this.whenCalledShowNext();
+        this.thenFireEventForPresenter("ID0", 0);
+    }
+
     private void givenWorkWith(String workWith){
         this.workWith = workWith;
     }


### PR DESCRIPTION
Po zrobieniu ticketu https://learneticsa.assembla.com/spaces/lorepo/tickets/7991--pearson--limited-gradual-show-answers/details?tab=activity do metody showNextAnswer przekazywane zaczęło być workWith jako string. Natomiast są prywatne addony, które samodzielnie używają tego addonu, więc dodana obsługa null, by nie musiały być one poprawiane.
Przykład gdzie to jest użyte i przestało działać:
https://test-8017-dot-mauthor-dev.ew.r.appspot.com/embed/5976758052454400
W pływającym po lewej stronie na dole module, środkowy przycisk pokazujący wyniki.