### PR TITLE
Fix after acceptance tests of media recorder extended mode, re #7932

### DIFF
--- a/addons/Media_Recorder/src/addon.xml
+++ b/addons/Media_Recorder/src/addon.xml
@@ -12,6 +12,8 @@
         <property name="isResetRemovesRecording" nameLabel="Media_Recorder_property_is_reset_removes_recording" type="boolean" />
         <property name="enableInErrorCheckingMode" nameLabel="Media_Recorder_property_enable_in_error_checking_mode" type="boolean" />
         <property name="extendedMode" nameLabel="Media_Recorder_property_extended_mode" type="boolean" />
+        <property name="disableRecording" nameLabel="Media_Recorder_property_is_disable_recording" type="boolean" />
+        <property name="enableIntensityChangeEvents" nameLabel="Media_Recorder_property_is_enable_intensity_events" type="boolean" />
         <property name="resetDialogLabels" nameLabel="Media_Recorder_property_reset_dialog_labels" type="staticlist">
 
             <property name="resetDialogText" nameLabel="Media_Recorder_property_reset_dialog_text" type="staticrow">

--- a/addons/Media_Recorder/src_webpack/recorder/AudioRecorder.jsm
+++ b/addons/Media_Recorder/src_webpack/recorder/AudioRecorder.jsm
@@ -8,14 +8,15 @@ export class AudioRecorder extends BaseRecorder {
 
         let options = {
             type: 'audio',
+            mimeType: 'audio/wav',
             numberOfAudioChannels: isEdge ? 1 : 2,
             checkForInactiveTracks: true,
             bufferSize: 16384,
             disableLogs: true,
+            recorderType: RecordRTC.StereoAudioRecorder,
         };
 
         if (isSafari) {
-            options.recorderType = StereoAudioRecorder;
             options.bufferSize = 4096;
             options.sampleRate = 44100;
         }

--- a/addons/Media_Recorder/src_webpack/validation/validateModel.jsm
+++ b/addons/Media_Recorder/src_webpack/validation/validateModel.jsm
@@ -29,6 +29,8 @@ export function validateModel(model) {
         ModelValidators.Boolean("enableInErrorCheckingMode"),
         ModelValidators.Boolean("isDisabled"),
         ModelValidators.Boolean("extendedMode"),
+        ModelValidators.Boolean("disableRecording"),
+        ModelValidators.Boolean("enableIntensityChangeEvents"),
         ModelValidators.StaticList('resetDialogLabels', {
             'resetDialogText': [ModelValidators.String('resetDialogLabel', {default: 'Are you sure you want to reset the recording?'})],
             'resetDialogConfirm': [ModelValidators.String('resetDialogLabel', {default: 'Yes'})],

--- a/addons/Media_Recorder/src_webpack/view/SoundIntensity.jsm
+++ b/addons/Media_Recorder/src_webpack/view/SoundIntensity.jsm
@@ -31,6 +31,11 @@ export class SoundIntensity {
         this.$view.css('display','none');
     }
 
+    setEventBus(eventBus, sourceID) {
+        this.eventBus = eventBus;
+        this.sourceID = sourceID;
+    }
+
     _updateIntensity(analyser) {
         let frequencyArray = new Uint8Array(analyser.frequencyBinCount);
         analyser.getByteFrequencyData(frequencyArray);
@@ -38,8 +43,28 @@ export class SoundIntensity {
         let raisedVolume = this._raiseVolume(avgVolume);
         let alignedVolume = this._alignVolume(raisedVolume);
         let intensity = alignedVolume * this.volumeLevels;
-
         this._setIntensity(intensity);
+        if (this.eventBus) {
+            this._handleEvents(intensity);
+        }
+    }
+
+    _handleEvents(intensity) {
+        if (this.lastIntensityLevel === undefined) {
+           this.lastIntensityLevel = 0;
+           return;
+        }
+        let newIntensityLevel = Math.floor(intensity);
+        if (newIntensityLevel !== this.lastIntensityLevel) {
+            this.lastIntensityLevel = newIntensityLevel;
+            var eventData = {
+                'source': this.sourceID,
+                'item': 'intensity',
+                'value': newIntensityLevel,
+                'score': ''
+            };
+            this.eventBus.sendEvent('ValueChanged', eventData);
+        }
     }
 
     _calculateAvgVolume(volumeArray) {

--- a/addons/Media_Recorder/src_webpack/view/button/DownloadButton.jsm
+++ b/addons/Media_Recorder/src_webpack/view/button/DownloadButton.jsm
@@ -16,13 +16,13 @@ export class DownloadButton extends Button {
     downloadRecording() {
         var element = document.createElement("a");
         element.setAttribute("id", "dl");
-        element.setAttribute("download", "recording.webm");
+        element.setAttribute("download", "recording.wav");
         element.setAttribute("href", "#");
         var base64Recording = this.addonState.recording;
         function handleDownloadRecording() {
             var data = base64Recording;
             data = data.replace(/^data:audio\/[^;]*/, 'data:application/octet-stream');
-            data = data.replace(/^data:application\/octet-stream/, 'data:application/octet-stream;headers=Content-Disposition%3A%20attachment%3B%20filename=recording.webm');
+            data = data.replace(/^data:application\/octet-stream/, 'data:application/octet-stream;headers=Content-Disposition%3A%20attachment%3B%20filename=recording.wav');
             this.href = data;
         }
         element.onclick = handleDownloadRecording;

--- a/addons/Media_Recorder/test/ModelUpgradeTest.js
+++ b/addons/Media_Recorder/test/ModelUpgradeTest.js
@@ -72,5 +72,35 @@ TestCase("[Media Recorder] Model upgrade", {
         assertTrue(upgradeModel["resetDialogLabels"]['resetDialogDeny'] !== undefined);
         assertTrue(upgradeModel["resetDialogLabels"]['resetDialogDeny']['resetDialogLabel'] !== undefined);
         assertEquals("3", upgradeModel["resetDialogLabels"]['resetDialogDeny']['resetDialogLabel']);
-    }
+    },
+
+    "test given model without disableRecording when _upgradeModel is called then disableRecording is added with default value": function () {
+        var upgradeModel = this.presenter._internalUpgradeModel(this.model);
+
+        assertTrue(upgradeModel["disableRecording"] !== undefined);
+        assertEquals("False", upgradeModel["disableRecording"]);
+    },
+
+    "test given model with disableRecording when _upgradeModel is called then disableRecording value remains unchanged": function () {
+        this.model["disableRecording"] = "True";
+        var upgradeModel = this.presenter._internalUpgradeModel(this.model);
+
+        assertTrue(upgradeModel["disableRecording"] !== undefined);
+        assertEquals("True", upgradeModel["disableRecording"]);
+    },
+
+    "test given model without enableIntensityChangeEvents when _upgradeModel is called then enableIntensityChangeEvents is added with default value": function () {
+        var upgradeModel = this.presenter._internalUpgradeModel(this.model);
+
+        assertTrue(upgradeModel["enableIntensityChangeEvents"] !== undefined);
+        assertEquals("False", upgradeModel["enableIntensityChangeEvents"]);
+    },
+
+    "test given model with enableIntensityChangeEvents when _upgradeModel is called then enableIntensityChangeEvents value remains unchanged": function () {
+        this.model["enableIntensityChangeEvents"] = "True";
+        var upgradeModel = this.presenter._internalUpgradeModel(this.model);
+
+        assertTrue(upgradeModel["enableIntensityChangeEvents"] !== undefined);
+        assertEquals("True", upgradeModel["enableIntensityChangeEvents"]);
+    },
 });

--- a/addons/Media_Recorder/test/ModelValidationTest.js
+++ b/addons/Media_Recorder/test/ModelValidationTest.js
@@ -18,6 +18,8 @@ TestCase("[Media Recorder] Model validation", {
             isDisabled: "False",
             enableInErrorCheckingMode: "False",
             extendedMode: "False",
+            disableRecording: "False",
+            enableIntensityChangeEvents: "False",
             resetDialogLabels: {
                 resetDialogText: {resetDialogLabel: ""},
                 resetDialogConfirm: {resetDialogLabel: ""},

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/bl/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/bl/dictionary.js
@@ -2044,6 +2044,8 @@ var ice_dictionary_bl = {
     "Media_Recorder_property_is_showed_timer": "Покажи таймер",
     "Media_Recorder_property_enable_in_error_checking_mode": "Enable in error checking mode",
     "Media_Recorder_property_extended_mode": "Extended mode",
+    "Media_Recorder_property_is_disable_recording": "Disable recording",
+    "Media_Recorder_property_is_enable_intensity_events": "Enable intensity change events",
     "Media_Recorder_property_reset_dialog_labels": "Reset dialog box",
     "Media_Recorder_property_reset_dialog_text": "Text",
     "Media_Recorder_property_reset_dialog_confirm": "Yes",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/com/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/com/dictionary.js
@@ -2050,6 +2050,8 @@ var ice_dictionary_en = {
     "Media_Recorder_property_is_showed_timer": "Show timer",
     "Media_Recorder_property_enable_in_error_checking_mode": "Enable in error checking mode",
     "Media_Recorder_property_extended_mode": "Extended mode",
+    "Media_Recorder_property_is_disable_recording": "Disable recording",
+    "Media_Recorder_property_is_enable_intensity_events": "Enable intensity change events",
     "Media_Recorder_property_reset_dialog_labels": "Reset dialog box",
     "Media_Recorder_property_reset_dialog_text": "Text",
     "Media_Recorder_property_reset_dialog_confirm": "Yes",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/fr/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/fr/dictionary.js
@@ -2029,6 +2029,8 @@ var ice_dictionary_fr = {
     "Media_Recorder_property_is_reset_removes_recording": "Reset removes recording",
     "Media_Recorder_property_enable_in_error_checking_mode": "Enable in error checking mode",
     "Media_Recorder_property_extended_mode": "Extended mode",
+    "Media_Recorder_property_is_disable_recording": "Disable recording",
+    "Media_Recorder_property_is_enable_intensity_events": "Enable intensity change events",
     "Media_Recorder_property_reset_dialog_labels": "Reset dialog box",
     "Media_Recorder_property_reset_dialog_text": "Text",
     "Media_Recorder_property_reset_dialog_confirm": "Yes",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/mx/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/mx/dictionary.js
@@ -2029,6 +2029,8 @@ var ice_dictionary_mx = {
     "Media_Recorder_property_is_reset_removes_recording": "Reset removes recording",
     "Media_Recorder_property_enable_in_error_checking_mode": "Enable in error checking mode",
     "Media_Recorder_property_extended_mode": "Extended mode",
+    "Media_Recorder_property_is_disable_recording": "Disable recording",
+    "Media_Recorder_property_is_enable_intensity_events": "Enable intensity change events",
     "Media_Recorder_property_reset_dialog_labels": "Reset dialog box",
     "Media_Recorder_property_reset_dialog_text": "Text",
     "Media_Recorder_property_reset_dialog_confirm": "Yes",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/pl/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/pl/dictionary.js
@@ -2028,6 +2028,8 @@ var ice_dictionary_pl = {
     "Media_Recorder_property_is_reset_removes_recording": "Reset removes recording",
     "Media_Recorder_property_enable_in_error_checking_mode": "Enable in error checking mode",
     "Media_Recorder_property_extended_mode": "Extended mode",
+    "Media_Recorder_property_is_disable_recording": "Disable recording",
+    "Media_Recorder_property_is_enable_intensity_events": "Enable intensity change events",
     "Media_Recorder_property_reset_dialog_labels": "Reset dialog box",
     "Media_Recorder_property_reset_dialog_text": "Text",
     "Media_Recorder_property_reset_dialog_confirm": "Yes",


### PR DESCRIPTION
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/realtime_cardwall?ticket=7932
PR: https://test-7932-dot-mauthor-dev.ew.r.appspot.com

- Dodałem dwa nowe propertiesy (jeden do wyłączenia nagrywania, drugi do włączenia eventów przy zmianie głośności), żeby spełnić wymaganie o trybie informowania o głośności sygnału z mikrofonu
- Poprawiłem błąd z brakiem możliwości pobrania nagrania po powrocie na stronę
- Odnośnie bardziej standardowego formatu pliku, zmodyfikowałem pobieranie, żeby pobierany był plik .wav zamiast .webm . Próbowałem jeszcze przerobić to na mp3, ale póki co bez sukcesu.