### PR TITLE
Test 8056 open ended contents

### DIFF
--- a/addons/Paragraph/src/presenter.js
+++ b/addons/Paragraph/src/presenter.js
@@ -827,6 +827,10 @@ function AddonParagraph_create() {
         return $wrapper[0].outerHTML;
     };
 
+    presenter.getOpenEndedContent = function () {
+        return presenter.getText();
+    }
+
     return presenter;
 }
 

--- a/addons/Paragraph/test/OpenEndedContentTests.js
+++ b/addons/Paragraph/test/OpenEndedContentTests.js
@@ -1,0 +1,31 @@
+TestCase("[Paragraph] Open ended content tests", {
+    setUp: function () {
+        this.presenter = AddonParagraph_create();
+        this.presenter.editor = {
+            id: "mce_1",
+            getContent: function () {
+                return;
+            }
+        };
+
+        this.stubs = {
+            getContent: sinon.stub(this.presenter.editor, 'getContent')
+        };
+    },
+
+    tearDown: function () {
+        if (this.presenter.editor) {
+            this.presenter.editor.getContent.restore();
+        }
+    },
+
+    'test when getOpenEndedContent is called then return editor content': function () {
+        this.stubs.getContent.returns("Content");
+
+        var result = this.presenter.getOpenEndedContent();
+
+        assertEquals("Content", result);
+    }
+
+});
+

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2021-07-30 Add getOpenEndedContentsForCurrentPage to PlayerServices
 2021-07-22 Add removeAllBookmarks command and tests to Navigation bar addon
 2021-07-12 Added math editor in popup property to WIRIS addon
 2021-07-12 Fixed Editable Window allowing for resizing of images when editing is disabled

--- a/src/main/java/com/lorepo/icplayer/client/content/services/JavaScriptPlayerServices.java
+++ b/src/main/java/com/lorepo/icplayer/client/content/services/JavaScriptPlayerServices.java
@@ -516,6 +516,10 @@ public class JavaScriptPlayerServices {
 			return x.@com.lorepo.icplayer.client.content.services.JavaScriptPlayerServices::getPagesMapping()();
 		}
 
+		playerServices.getOpenEndedContentForCurrentPage = function () {
+			return x.@com.lorepo.icplayer.client.content.services.JavaScriptPlayerServices::getOpenEndedContentForCurrentPage()();
+		}
+
 		return playerServices;
 	}-*/;
 
@@ -993,4 +997,6 @@ public class JavaScriptPlayerServices {
 	public ObserverJSService getJSObserverService() {
 		return playerServices.getObserverService().getAsJS();
 	}
+
+	private JavaScriptObject getOpenEndedContentForCurrentPage() { return this.playerServices.getOpenEndedContentForCurrentPage(); }
 }

--- a/src/main/java/com/lorepo/icplayer/client/content/services/PlayerServices.java
+++ b/src/main/java/com/lorepo/icplayer/client/content/services/PlayerServices.java
@@ -10,7 +10,10 @@ import com.lorepo.icplayer.client.PlayerController;
 import com.lorepo.icplayer.client.content.services.dto.ScaleInformation;
 import com.lorepo.icplayer.client.content.services.externalNotifications.IObserverService;
 import com.lorepo.icplayer.client.content.services.externalNotifications.ObserverService;
+import com.lorepo.icplayer.client.model.page.Page;
 import com.lorepo.icplayer.client.model.page.group.GroupPresenter;
+import com.lorepo.icplayer.client.module.IOpenEndedContentPresenter;
+import com.lorepo.icplayer.client.module.api.IModuleModel;
 import com.lorepo.icplayer.client.module.api.IPlayerStateService;
 import com.lorepo.icplayer.client.module.api.IPresenter;
 import com.lorepo.icplayer.client.module.api.player.*;
@@ -415,5 +418,27 @@ public class PlayerServices implements IPlayerServices {
 	@Override
 	public IAdaptiveLearningService getAdaptiveLearningService() {
 		return this.playerController.getAdaptiveLearningService();
+	}
+
+	@Override
+	public JavaScriptObject getOpenEndedContentForCurrentPage() {
+		JavaScriptObject contents = JavaScriptUtils.createJSObject();
+		int pageIndex = playerController.getCurrentPageIndex();
+		IPage ipage = playerController.getModel().getPage(pageIndex);
+		if (ipage instanceof Page) {
+			Page page = (Page) ipage;
+			for (int i = 0; i < page.getModules().size(); i++) {
+				IModuleModel model = page.getModules().get(i);
+				IPresenter ipresenter = getModule(model.getId());
+				if (ipresenter instanceof IOpenEndedContentPresenter) {
+					IOpenEndedContentPresenter presenter = (IOpenEndedContentPresenter) ipresenter;
+					String content = presenter.getOpenEndedContent();
+					if (content != null) {
+						JavaScriptUtils.addPropertyToJSArray(contents, model.getId(), content);
+					}
+				}
+			}
+		}
+		return contents;
 	}
 }

--- a/src/main/java/com/lorepo/icplayer/client/module/IOpenEndedContentPresenter.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/IOpenEndedContentPresenter.java
@@ -1,0 +1,9 @@
+package com.lorepo.icplayer.client.module;
+
+
+public interface IOpenEndedContentPresenter {
+	// If the presenter may but doesn't have to contain open ended content,
+	// such as in the case of the AddonPresenter this method will return null
+	// if there is no open ended content
+	public String getOpenEndedContent();
+}

--- a/src/main/java/com/lorepo/icplayer/client/module/addon/AddonPresenter.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/addon/AddonPresenter.java
@@ -29,6 +29,7 @@ import com.lorepo.icf.scripting.IType;
 import com.lorepo.icf.utils.StringUtils;
 import com.lorepo.icf.utils.URLUtils;
 import com.lorepo.icplayer.client.content.services.PlayerEventBusWrapper;
+import com.lorepo.icplayer.client.module.IOpenEndedContentPresenter;
 import com.lorepo.icplayer.client.module.IWCAG;
 import com.lorepo.icplayer.client.module.IWCAGModuleView;
 import com.lorepo.icplayer.client.module.IWCAGPresenter;
@@ -43,7 +44,7 @@ import com.lorepo.icplayer.client.page.KeyboardNavigationController;
 import com.lorepo.icplayer.client.page.PageController;
 
 
-public class AddonPresenter implements IPresenter, IActivity, IStateful, ICommandReceiver, IWCAGPresenter, IWCAG, IWCAGModuleView, IGradualShowAnswersPresenter {
+public class AddonPresenter implements IPresenter, IActivity, IStateful, ICommandReceiver, IWCAGPresenter, IWCAG, IWCAGModuleView, IGradualShowAnswersPresenter, IOpenEndedContentPresenter {
 
 	public interface IDisplay extends IModuleView{
 		public Element getElement();
@@ -623,6 +624,19 @@ public class AddonPresenter implements IPresenter, IActivity, IStateful, IComman
 	private native void setEventBus(JavaScriptObject presenter, JavaScriptObject eventBusWrapper) /*-{
 		if (presenter.setEventBus != undefined) {
 			presenter.setEventBus(eventBusWrapper);
+		}
+	}-*/;
+
+	@Override
+	public String getOpenEndedContent() {
+		return getOpenEndedContent(jsObject);
+	}
+
+	private native String getOpenEndedContent(JavaScriptObject presenter)/*-{
+		if (presenter && presenter.hasOwnProperty("getOpenEndedContent")) {
+			return presenter.getOpenEndedContent();
+		} else {
+			return null;
 		}
 	}-*/;
 }

--- a/src/main/java/com/lorepo/icplayer/client/module/api/player/IPlayerServices.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/api/player/IPlayerServices.java
@@ -53,6 +53,7 @@ public interface IPlayerServices {
 
 	public void setExternalVariable(String key, String value);
 	public String getExternalVariable(String key);
+	public JavaScriptObject getOpenEndedContentForCurrentPage();
 
 	@Deprecated
 	public EventBus	getEventBus();

--- a/src/test/java/com/lorepo/icplayer/client/mockup/services/PlayerServicesMockup.java
+++ b/src/test/java/com/lorepo/icplayer/client/mockup/services/PlayerServicesMockup.java
@@ -268,6 +268,11 @@ public class PlayerServicesMockup implements IPlayerServices {
 	}
 
 	@Override
+	public JavaScriptObject getOpenEndedContentForCurrentPage() {
+		return null;
+	}
+
+	@Override
 	public void sendResizeEvent() {
 		// TODO Auto-generated method stub
 	}

--- a/src/test/java/com/lorepo/icplayer/client/module/addon/OpenEndedContentTestCase.java
+++ b/src/test/java/com/lorepo/icplayer/client/module/addon/OpenEndedContentTestCase.java
@@ -1,0 +1,25 @@
+package com.lorepo.icplayer.client.module.addon;
+
+import com.lorepo.icplayer.client.GWTPowerMockitoTest;
+import com.lorepo.icplayer.client.mockup.services.PlayerServicesMockup;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class OpenEndedContentTestCase extends GWTPowerMockitoTest {
+
+	@Test
+	public void whenCallingGetOpenEndedContentThenReturnAddonsOpenEndedContentValue() throws SAXException, IOException {
+		PlayerServicesMockup services = new PlayerServicesMockup();
+		AddonModel module = new AddonModel();
+		AddonPresenter addon = new AddonPresenter(module, services);
+
+		String openEndedContent = addon.getOpenEndedContent();
+
+		assertEquals("Open Ended Content For Addon", openEndedContent);
+	}
+
+}

--- a/src/test/java/com/lorepo_patchers/icplayer/client/module/addon/AddonPresenterPatcher.java
+++ b/src/test/java/com/lorepo_patchers/icplayer/client/module/addon/AddonPresenterPatcher.java
@@ -1,0 +1,16 @@
+package com.lorepo_patchers.icplayer.client.module.addon;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.googlecode.gwt.test.patchers.PatchClass;
+import com.googlecode.gwt.test.patchers.PatchMethod;
+import com.lorepo.icplayer.client.module.addon.AddonPresenter;
+
+
+@PatchClass(AddonPresenter.class)
+public class AddonPresenterPatcher {
+
+    @PatchMethod
+    public static String getOpenEndedContent(AddonPresenter self, JavaScriptObject presenter) {
+        return "Open Ended Content For Addon";
+    }
+}


### PR DESCRIPTION
ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/realtime_cardwall?tickets_report_id=filter:0&ticket=8056
Wersja testowa: https://test-8056-dot-mauthor-dev.ew.r.appspot.com/embed/6083464736538624

Dodałem nową metodę do PlayerServices: getOpenEndedContentForCurrentPage(), która zwraca dict, gdzie klucze to ID paragrafów na obecnej stronie, a value to zawartości tych addonów. Metodę można wywołąć z konsoli w następujący sposób:

player.getPlayerServices().getOpenEndedContentForCurrentPage();