### PR TITLE
Add printable state for text selection addon, re #8058

### DIFF
--- a/addons/Text_Selection/src/presenter.js
+++ b/addons/Text_Selection/src/presenter.js
@@ -12,6 +12,7 @@ function AddonText_Selection_create() {
     presenter._keyboardController = null;
     presenter._firstElementSwitch = true;
     presenter.isGradualShowAnswersActive = false;
+    presenter.printableState = null;
     var isWCAGOn = false;
 
     var SELECTED_SECTION_START = "&\n&SELECTED_SECTION_START&\n&";
@@ -34,6 +35,13 @@ function AddonText_Selection_create() {
         presenter.eventBus = controller.getEventBus();
         presenter.textParser = new TextParserProxy(controller.getTextParser());
     };
+
+    /**
+     * @param controller (PrintableController)
+     */
+    presenter.setPrintableController = function (controller) {
+        presenter.textParser = new TextParserProxy(controller.getTextParser());
+    }
 
     function getEventData(it, val, sc) {
         return {
@@ -1702,6 +1710,13 @@ function AddonText_Selection_create() {
             }
         } while (match);
         return false;
+    };
+
+    presenter.setPrintableState = function(state) {
+        if (state === null || ModelValidationUtils.isStringEmpty(state))
+            return;
+
+        presenter.printableState = JSON.parse(state);
     };
 
     presenter.getPrintableHTML = function (model, showAnswers) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2021-07-30 Added printable state for text selection
 2021-07-22 Add removeAllBookmarks command and tests to Navigation bar addon
 2021-07-12 Added math editor in popup property to WIRIS addon
 2021-07-12 Fixed Editable Window allowing for resizing of images when editing is disabled


### PR DESCRIPTION
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/8058--drukowanie--text-selection---za%C5%82adowanie-stanu
Wersja testowa: https://test-8058-dot-mauthor-dev.ew.r.appspot.com
Lekcja testowa: https://test-8058-dot-mauthor-dev.ew.r.appspot.com/embed/5520387712483328

W wersji testowej nie ma zbytnio czego sprawdzać.