### PR TITLE
 feat(addon): Naprawa buga związanego z nie wysyłaniem eventu stop w MediaRecorder re #8036

### DIFF
--- a/addons/Media_Recorder/src/presenter.js
+++ b/addons/Media_Recorder/src/presenter.js
@@ -613,6 +613,12 @@ var MediaRecorder = exports.MediaRecorder = function () {
         value: function setPlayerController(playerController) {
             this.playerController = playerController;
             if (this.player && this.recorder) this._loadEventBus();
+
+            var context = playerController.getContextMetadata();
+            this.isMlibro = false;
+            if (context != null && "ismLibro" in context) {
+                this.isMlibro = context["ismLibro"];
+            }
         }
     }, {
         key: "getState",
@@ -850,6 +856,7 @@ var MediaRecorder = exports.MediaRecorder = function () {
         value: function _loadMediaElements() {
             this.recorder = new _AudioRecorder.AudioRecorder();
             this.player = new _AudioPlayer.AudioPlayer(this.viewHandlers.$playerView);
+            this.player.setIsMlibro(this.isMlibro);
             this.defaultRecordingPlayer = new _AudioPlayer.AudioPlayer(this.viewHandlers.$playerView);
             this.resourcesProvider = new _AudioResourcesProvider.AudioResourcesProvider(this.viewHandlers.$wrapperView);
             if (this.playerController) this._loadEventBus();
@@ -3384,7 +3391,8 @@ var BasePlayer = exports.BasePlayer = function (_Player) {
         value: function stopStreaming() {
             // for some reason Edge doesn't send pause event in stopPlaying
             // and setting stopNextStopEvent to true will cause it to not send stop event after finishing playing recorded sound
-            if (!this.mediaNode.paused && !DevicesUtils.isEdge()) {
+            // same as above but with mLibro on android
+            if (!this.mediaNode.paused && !DevicesUtils.isEdge() && !this.isMlibro) {
                 this.stopNextStopEvent = true;
             }
 
@@ -3428,6 +3436,11 @@ var BasePlayer = exports.BasePlayer = function (_Player) {
         key: "getCurrentTime",
         value: function getCurrentTime() {
             return this.mediaNode.currentTime;
+        }
+    }, {
+        key: "setIsMlibro",
+        value: function setIsMlibro(isMlibro) {
+            this.isMlibro = isMlibro;
         }
     }, {
         key: "_enableEventsHandling",
@@ -3606,6 +3619,11 @@ var Player = exports.Player = function () {
         key: "setEventBus",
         value: function setEventBus(eventBus, sourceID) {
             throw new Error("setEventBus method is not implemented");
+        }
+    }, {
+        key: "setIsMlibro",
+        value: function setIsMlibro(isMlibro) {
+            throw new Error("setIsMlibro method is not implemented");
         }
     }, {
         key: "reset",

--- a/addons/Media_Recorder/src_webpack/MediaRecorder.jsm
+++ b/addons/Media_Recorder/src_webpack/MediaRecorder.jsm
@@ -54,6 +54,12 @@ export class MediaRecorder {
         this.playerController = playerController;
         if (this.player && this.recorder)
             this._loadEventBus()
+
+        var context = playerController.getContextMetadata();
+        this.isMlibro = false;
+        if (context != null && "ismLibro" in context) {
+            this.isMlibro = context["ismLibro"];
+        }
     }
 
     getState() {
@@ -274,6 +280,7 @@ export class MediaRecorder {
     _loadMediaElements() {
         this.recorder = new AudioRecorder();
         this.player = new AudioPlayer(this.viewHandlers.$playerView);
+        this.player.setIsMlibro(this.isMlibro);
         this.defaultRecordingPlayer = new AudioPlayer(this.viewHandlers.$playerView);
         this.resourcesProvider = new AudioResourcesProvider(this.viewHandlers.$wrapperView);
         if (this.playerController)

--- a/addons/Media_Recorder/src_webpack/player/BasePlayer.jsm
+++ b/addons/Media_Recorder/src_webpack/player/BasePlayer.jsm
@@ -83,7 +83,8 @@ export class BasePlayer extends Player {
     stopStreaming() {
         // for some reason Edge doesn't send pause event in stopPlaying
         // and setting stopNextStopEvent to true will cause it to not send stop event after finishing playing recorded sound
-        if (!this.mediaNode.paused && !DevicesUtils.isEdge()) {
+        // same as above but with mLibro on android
+        if (!this.mediaNode.paused && !DevicesUtils.isEdge() && !this.isMlibro) {
             this.stopNextStopEvent = true;
         }
 
@@ -123,6 +124,10 @@ export class BasePlayer extends Player {
 
     getCurrentTime() {
         return this.mediaNode.currentTime;
+    }
+
+    setIsMlibro(isMlibro) {
+        this.isMlibro = isMlibro;
     }
 
     _enableEventsHandling() {

--- a/addons/Media_Recorder/src_webpack/player/Player.jsm
+++ b/addons/Media_Recorder/src_webpack/player/Player.jsm
@@ -41,6 +41,10 @@ export class Player {
         throw new Error("setEventBus method is not implemented");
     }
 
+    setIsMlibro(isMlibro) {
+        throw new Error("setIsMlibro method is not implemented");
+    }
+
     reset() {
         throw new Error("Reset method is not implemented");
     }

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2021-09-03 Fix bug with no event on stop recording android mLibro
 2021-08-31 Add ScoreWithMetadata API
 2021-08-24 Fix bug with eKeyboard going to next input
 2021-08-16 Add Gradual Show Answer to Point and Lines addon


### PR DESCRIPTION
Wersja testowa: https://test-8036-dot-mcourser-dev.appspot.com
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/8036--android--blokowanie-przycisk%C3%B3w-po-odtworzeniu-nagrywania-d%C5%BAwi%C4%99ku/details?tab=activity#