### PR TITLE
fix(addon): Poprawienie trimowania textu przy sprawdzaniu poprawnej odpowiedzi re #8160

### DIFF
--- a/src/main/java/com/lorepo/icplayer/client/module/text/GapWidget.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/GapWidget.java
@@ -234,6 +234,7 @@ public class GapWidget extends TextBox implements TextElementDisplay {
 			String placeholder = this.gapInfo.getPlaceHolder().trim();
 			boolean isTextOnlyPlaceholder = this.ignorePlaceholder && text == placeholder;
 			this.isWorkingMode = false;
+			text = text.trim();
 
 			if (text.length() > 0 && !isTextOnlyPlaceholder) {
 				if (gapInfo.isCorrect(text)) {


### PR DESCRIPTION
Wersja testowa: https://test-8160-dot-mauthor-dev.ew.r.appspot.com/embed/5388322098642944
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/8160--aga--text---spacja-na-ko%C5%84cu-gapy-zmienia-na-wrong/details#