### PR TITLE
fix(addon): Naprawa pozycji popupu w oparciu o pozycje absolute parenta re #7729

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2021-11-05 Fixed popup absolute position according to absolute parent
 2021-10-22 Fixed flashcard audio after finished record not returning to play state
 2021-10-20 Add new characters to French ekeyboard and change it's order
 2021-10-13 Fix dropdownClicked event received behaviour in Audio, TextAudio and Video addon

--- a/src/main/java/com/lorepo/icplayer/client/page/PagePopupPanel.java
+++ b/src/main/java/com/lorepo/icplayer/client/page/PagePopupPanel.java
@@ -235,8 +235,8 @@ public class PagePopupPanel extends DialogBox {
 			}
 
 			if(this.top != null && this.top != "" && this.left != null && this.left != "" && isInteger(this.left) && isInteger(this.top)){
-				int propertyLeft = scaleInt(Integer.parseInt(this.left), scale.scaleX);
-				int propertyTop = scaleInt(Integer.parseInt(this.top), scale.scaleY);
+				int propertyLeft = scaleInt(Integer.parseInt(this.left) + parentWidget.getAbsoluteLeft(), scale.scaleX);
+				int propertyTop = scaleInt(Integer.parseInt(this.top) + parentWidget.getAbsoluteTop(), scale.scaleY);
 				setPopupPosition(propertyLeft, propertyTop);
 			} else if (this.top != null && this.top != "" && isInteger(this.top)) {
 				int propertyTop = scaleInt(Integer.parseInt(this.top), scale.scaleY);


### PR DESCRIPTION
Wersja testowa: 
- mc: https://test-7729-dot-mcourser-dev.appspot.com/
- ma: https://test-7729-dot-mauthor-dev.ew.r.appspot.com
Ticket : https://learneticsa.assembla.com/spaces/lorepo/tickets/7729--bug--sejer--popup-wywo%C5%82any-z-okre%C5%9Blon%C4%85-pozycj%C4%85-%C5%BAle-wy%C5%9Bw/details#