### PR TITLE
feat(addon): Dodanie opcjonalnego parametru dontSendEvent do komend select/deselect w addonie ImageIdentification re #7816

### DIFF
--- a/addons/Image_Identification/documentation.md
+++ b/addons/Image_Identification/documentation.md
@@ -66,12 +66,12 @@ It's very good practice to set the Image property in a form of the sprite image 
     </tr>
     <tr>
         <td>select</td>
-        <td>---</td>
+        <td><i>optional</i> dontSendEvent: true/false</td>
         <td>Select an element if not selected (not available in the error checking mode)</td>
     </tr>
     <tr>
         <td>deselect</td>
-        <td>---</td>
+        <td><i>optional</i> dontSendEvent: true/false</td>
         <td>Deselect an element if selected (not available in the error checking mode)</td>
     </tr>
     <tr>

--- a/addons/Image_Identification/src/presenter.js
+++ b/addons/Image_Identification/src/presenter.js
@@ -493,15 +493,19 @@ function AddonImage_Identification_create(){
         playerController = controller;
     };
 
-    presenter.select = function () {
+    presenter.select = function (dontSendEvent) {
         presenter.configuration.isSelected = true;
-        presenter.triggerSelectionEvent(true, presenter.configuration.shouldBeSelected);
+        if (!dontSendEvent) {
+            presenter.triggerSelectionEvent(true, presenter.configuration.shouldBeSelected);
+        }
         applySelectionStyle(true, CSS_CLASSES.SELECTED, CSS_CLASSES.ELEMENT);
     };
 
-    presenter.deselect = function () {
+    presenter.deselect = function (dontSendEvent) {
         presenter.configuration.isSelected = false;
-        presenter.triggerSelectionEvent(false, presenter.configuration.shouldBeSelected);
+        if (!dontSendEvent) {
+            presenter.triggerSelectionEvent(false, presenter.configuration.shouldBeSelected);
+        }
         applySelectionStyle(false, CSS_CLASSES.SELECTED, CSS_CLASSES.ELEMENT);
     };
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2021-11-05 Add dontSendEvent param to select/deselect commands in Addon ImageIdentification
 2021-10-22 Fixed flashcard audio after finished record not returning to play state
 2021-10-20 Add new characters to French ekeyboard and change it's order
 2021-10-13 Fix dropdownClicked event received behaviour in Audio, TextAudio and Video addon


### PR DESCRIPTION
Wersja testowa: https://test-7816-dot-mauthor-dev.ew.r.appspot.com
Ticket : https://learneticsa.assembla.com/spaces/lorepo/tickets/7816--new--zmiana-wysy%C5%82ania-eventu-na-select()-w-image-identification/details#