### PR TITLE
Fixed issue with non-letter/number signs in module ids, re #8254

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2022-01-10 Fixed issue with module ids including non-letter/number signs
 2021-12-15 Added event on blur in Paragraph Keyboard addon
 2021-12-14 Added audio speed controller to Audio Playlist
 2021-12-14 Prevent from adding the dragging class to checked element in Multiple Gap

--- a/src/main/java/com/lorepo/icplayer/client/module/NestedAddonUtils.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/NestedAddonUtils.java
@@ -44,8 +44,9 @@ public class NestedAddonUtils {
     public static native boolean insertIntoAddonGap(String moduleID, Element view, Element page) /*-{
 		var idPrefix = @com.lorepo.icplayer.client.module.NestedAddonUtils::ID_PREFIX;
 		var idEditorPrefix = @com.lorepo.icplayer.client.module.NestedAddonUtils::ID_EDITOR_PREFIX;
-		var $addonGap = $wnd.$(page).find('#' + idPrefix + moduleID);
-		if ($addonGap.length == 0) $addonGap = $wnd.$(page).find('#'+idEditorPrefix + moduleID);
+		var escapedModuleID = moduleID.replace(/[ .*+?^${}()|[\]\\]/g, '\\$&');
+		var $addonGap = $wnd.$(page).find('#' + idPrefix + escapedModuleID);
+		if ($addonGap.length == 0) $addonGap = $wnd.$(page).find('#'+idEditorPrefix + escapedModuleID);
 		if ($addonGap.length == 0) return false;
 		view.classList.add("inner_addon");
 		$addonGap.first().replaceWith(view);


### PR DESCRIPTION
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/8254-b%C5%82%C4%99dne-id-modu%C5%82u-zawiesza-stron%C4%99-w-edytorze/details?comment=1696230275
Wersja testowa: https://test-8254-dot-mauthor-dev.ew.r.appspot.com/embed/5832769173192704