### PR TITLE
fix(player/editor): Extented chars to be escaped when using jQuery find in NestedAddonUtils re #8276

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2022-02-02 Fixed Addon containing special chars in its ID
 2022-01-24 Fixed video addon progress bar issues on mobiles - fullscreen changed first click and offset between click and actual
 2022-01-12 Added setAllPagesAsVisited command
 2022-01-10 Fixed issue with module ids including non-letter/number signs

--- a/src/main/java/com/lorepo/icplayer/client/module/NestedAddonUtils.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/NestedAddonUtils.java
@@ -44,7 +44,7 @@ public class NestedAddonUtils {
     public static native boolean insertIntoAddonGap(String moduleID, Element view, Element page) /*-{
 		var idPrefix = @com.lorepo.icplayer.client.module.NestedAddonUtils::ID_PREFIX;
 		var idEditorPrefix = @com.lorepo.icplayer.client.module.NestedAddonUtils::ID_EDITOR_PREFIX;
-		var escapedModuleID = moduleID.replace(/[ .*+?^${}()|[\]\\]/g, '\\$&');
+		var escapedModuleID = moduleID.replace(/[ !"#$%&'()*+,.:;<=>?@[^`{|}~\/\]]/g, '\\$&'); //regex to escape jQuery selectors - https://api.jquery.com/category/selectors/
 		var $addonGap = $wnd.$(page).find('#' + idPrefix + escapedModuleID);
 		if ($addonGap.length == 0) $addonGap = $wnd.$(page).find('#'+idEditorPrefix + escapedModuleID);
 		if ($addonGap.length == 0) return false;


### PR DESCRIPTION
Wersja testowa: https://test-8276-dot-mauthor-dev.ew.r.appspot.com
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/8276-id-modu%C5%82u-zawieraj%C4%85ce-dwukropek-zawiesza-stron%C4%99-w-edytorze/details?tab=activity#