### PR TITLE
fix(addon): Fix in MediaRecorder when signal is in Mono re #ML-1586

### DIFF
--- a/addons/Media_Recorder/src_webpack/state/service/BlobService.jsm
+++ b/addons/Media_Recorder/src_webpack/state/service/BlobService.jsm
@@ -40,7 +40,10 @@ export class BlobService {
 
     static getMp3BlobFromDecodedData(decodedData) {       
         let left = this._convertFloat32ToInt16Array(decodedData.getChannelData(0));
-        let right = this._convertFloat32ToInt16Array(decodedData.getChannelData(1));
+        let right = left;
+        if (decodedData.numberOfChannels === 2) {
+            right = this._convertFloat32ToInt16Array(decodedData.getChannelData(1));
+        }
 
         return this._encode(decodedData.numberOfChannels, decodedData.sampleRate, decodedData.length, left, right);       
     }


### PR DESCRIPTION
Wersja testowa: https://test-1586-dot-mauthor-dev.ew.r.appspot.com
Ticket: https://learneticsa.assembla.com/spaces/mlibro/tickets/1586--sejer--b%C5%82%C4%85d-pobierania-nagranego-dzwi%C4%99ku-w-aplikacji--exe-/details#