### PR TITLE
Fix visible lines after hide and show\hide answers in Points and Lines addon, re #8344

### DIFF
--- a/addons/PointsLines/src/presenter.js
+++ b/addons/PointsLines/src/presenter.js
@@ -1100,7 +1100,7 @@ function AddonPointsLines_create() {
             presenter.answersNumber = 0;
             presenter.isGradualShowAnswersActive = false;
             presenter.$view.find('.line-show-answer').remove();
-            presenter.$view.find('.line').css("visibility", "visible");
+            presenter.$view.find('.line').css("visibility", "inherit");
         }
     }
 
@@ -1128,7 +1128,7 @@ function AddonPointsLines_create() {
         if (presenter.activity && presenter.isShowAnswersActive) {
             presenter.isShowAnswersActive = false;
             presenter.$view.find('.line-show-answer').remove();
-            presenter.$view.find('.line').css("visibility", "visible");
+            presenter.$view.find('.line').css("visibility", "inherit");
         }
     };
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2022-03-30 Fixed visible lines after hide and show\hide answers in Points and Lines addon
 2022-03-14 Fixed video speed controls adding whenever reset was called
 2022-03-14 Added TTS to Table of Contents
 2022-03-04 Added SrtParser to commons. Added audio narration loading from SRT File to AddonAudio addon


### PR DESCRIPTION
[Link do zadania](https://learneticsa.assembla.com/spaces/lorepo/tickets/8344-points-and-lines---poprawka/details)
[Link do wersji testowej](https://test-8344-dot-mauthor-dev.ew.r.appspot.com)
[Link do lekcji testowej](https://test-8344-dot-mauthor-dev.ew.r.appspot.com/embed/5914603198349312)
[Link do tej samej lekcji testowej, przed wprowadzeniem zmian](https://test-8312-dot-mauthor-dev.ew.r.appspot.com/embed/5914603198349312)