### PR TITLE
Fix commands to bookmark and unbookmark pages not visible in Assessments_Navigation_Bar addon, re #8333

### DIFF
--- a/addons/Assessments_Navigation_Bar/src/presenter.js
+++ b/addons/Assessments_Navigation_Bar/src/presenter.js
@@ -38,6 +38,8 @@ function AddonAssessments_Navigation_Bar_create(){
         BUTTON: "button",
         TURN_BACK: "turn_back",
         TURN_FORWARD: "turn_forward",
+        CURRENT_PAGE: "current_page",
+        BOOKMARK: "bookmark",
     };
 
     presenter.attemptedButtons = [];
@@ -271,15 +273,15 @@ function AddonAssessments_Navigation_Bar_create(){
 
     presenter.Button.prototype.setAsCurrent = function () {
         this.isActualButton = true;
-        this.$view.addClass("current_page");
+        this.$view.addClass(presenter.CSS_CLASSES.CURRENT_PAGE);
     };
 
     presenter.Button.prototype.addBookmark = function () {
-        this.$view.addClass("bookmark");
+        this.$view.addClass(presenter.CSS_CLASSES.BOOKMARK);
     };
 
     presenter.Button.prototype.removeBookmark = function () {
-        this.$view.removeClass("bookmark");
+        this.$view.removeClass(presenter.CSS_CLASSES.BOOKMARK);
     };
 
     presenter.Button.prototype.createView = function () {
@@ -605,9 +607,10 @@ function AddonAssessments_Navigation_Bar_create(){
     };
 
     presenter.NavigationManager.prototype.bookmarkCurrentButton = function () {
-        this.buttons.filter(function (element) {
+        var currentButton = this.buttons.filter(function (element) {
             return element.isActualButton;
-        })[0].addBookmark();
+        })[0];
+        if (currentButton !== undefined) currentButton.addBookmark();
     };
 
     presenter.NavigationManager.prototype.removeBookmarksFromButtons = function () {
@@ -621,9 +624,10 @@ function AddonAssessments_Navigation_Bar_create(){
     };
 
     presenter.NavigationManager.prototype.removeBookmarkFromCurrentButton = function () {
-        this.buttons.filter(function (element) {
+        var currentButton = this.buttons.filter(function (element) {
             return element.isActualButton;
-        })[0].removeBookmark();
+        })[0];
+        if (currentButton !== undefined) currentButton.removeBookmark();
     };
 
     presenter.NavigationManager.prototype.markButtonsWithAttempted = function (attemptedPages) {
@@ -1523,7 +1527,7 @@ function AddonAssessments_Navigation_Bar_create(){
 
             var keyboardElements = presenter.keyboardControllerObject.keyboardNavigationElements;
             for (var i = 0; i < keyboardElements.length; i++) {
-                if ($(keyboardElements[i]).hasClass('current_page')) {
+                if ($(keyboardElements[i]).hasClass(presenter.CSS_CLASSES.CURRENT_PAGE)) {
                     presenter.keyboardControllerObject.keyboardNavigationCurrentElementIndex = i;
                 }
             }

--- a/addons/Assessments_Navigation_Bar/test/CommandsTests.js
+++ b/addons/Assessments_Navigation_Bar/test/CommandsTests.js
@@ -78,6 +78,50 @@ TestCase("[Assessments_Navigation_Bar] add / remove Bookmark", {
     }
 });
 
+TestCase("[Assessments_Navigation_Bar] add / remove Bookmark from not visible button", {
+    setUp: function () {
+        this.presenter = AddonAssessments_Navigation_Bar_create();
+        this.sections = [
+            {
+                sectionName: "",
+                pages: [0, 1, 2],
+                pagesDescriptions: ["0", "1", "2"]
+            }
+        ];
+        this.presenter.sections = new this.presenter.Sections(this.sections);
+
+        this.presenter.buttons = [];
+
+        this.stubs = {
+            initView: sinon.stub(this.presenter.NavigationManager.prototype, 'initView'),
+            isActualPage1: sinon.stub(this.presenter.sections.allPages[0], 'isActualPage'),
+            isActualPage2: sinon.stub(this.presenter.sections.allPages[1], 'isActualPage'),
+            isActualPage3: sinon.stub(this.presenter.sections.allPages[2], 'isActualPage'),
+        };
+
+        this.stubs.isActualPage1.returns(false);
+        this.stubs.isActualPage2.returns(true);
+        this.stubs.isActualPage3.returns(false);
+
+        this.presenter.navigationManager = new this.presenter.NavigationManager(0);
+    },
+
+    tearDown: function () {
+        this.presenter.NavigationManager.prototype.initView.restore();
+        this.presenter.sections.allPages[0].isActualPage.restore();
+        this.presenter.sections.allPages[1].isActualPage.restore();
+        this.presenter.sections.allPages[2].isActualPage.restore();
+    },
+
+    'test bookmarking current page that is not visible should not raise error': function () {
+        this.presenter.bookmarkCurrentPage();
+    },
+
+    'test removing bookmark from current page that is not visible should not raise error': function () {
+        this.presenter.removeBookmark();
+    },
+});
+
 TestCase("[Assessments_Navigation_Bar] Move to page", {
     setUp: function () {
         this.presenter = AddonAssessments_Navigation_Bar_create();

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2022-03-31 Fixed commands to bookmark and unbookmark pages not visible in Assessments_Navigation_Bar addon
 2022-03-14 Fixed video speed controls adding whenever reset was called
 2022-03-14 Added TTS to Table of Contents
 2022-03-04 Added SrtParser to commons. Added audio narration loading from SRT File to AddonAudio addon


### PR DESCRIPTION
[Link do zadania](https://learneticsa.assembla.com/spaces/lorepo/tickets/8333--pearson--assessment-navigation-bar---b%C5%82%C4%85d-modu%C5%82u-po-klikni%C4%99ciu/details)
[Link do wersji testowej](https://test-8333-dot-mauthor-dev.ew.r.appspot.com)
[Link do lekcji testowej](https://test-8333-dot-mauthor-dev.ew.r.appspot.com/embed/5923825969528832#3)