### PR TITLE
Add event when Editable Window is closed, re #8350

### DIFF
--- a/addons/EditableWindow/src/presenter.js
+++ b/addons/EditableWindow/src/presenter.js
@@ -970,6 +970,15 @@ function AddonEditableWindow_create() {
         $(presenter.configuration.view).hide();
         presenter.stopAudio();
         presenter.stopVideo();
+
+        var eventBus = presenter.configuration.eventBus;
+        var id = presenter.configuration.model.id;
+        eventBus.sendEvent('ValueChanged', {
+            'source': id,
+            'item': '',
+            'value': 'close',
+            'score': ''
+        });
     };
 
     presenter.disableWCAGIfTTSOrKeyboardNav = function EditableWindow_disableWCAGIfTTSOrKeyboardNav() {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2022-05-16 Added an event when Editable Window is closed
 2022-05-13 Added Show Answers property to Paragraph Keyboard
 2022-05-13 Implemented extended auto navigation for addon Crossword
 2022-05-13 Fixed problem with unchecking in limited check and check combinations


### PR DESCRIPTION
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/8350--pearson-global--editable-window-%E2%80%93%C2%A0brakuj%C4%85cy-event-na-zamkni%C4%99ci/details?comment=1699252938
Wersja testowa: https://test-8350-dot-mauthor-dev.ew.r.appspot.com/embed/6331285389705216