### PR TITLE
TTS keyboard navigation no longer ignores disabled addons, re #8393

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2022-05-18 TTS keyboard navigation no longer ignores disabled addons
 2022-05-13 Added Show Answers property to Paragraph Keyboard
 2022-05-13 Implemented extended auto navigation for addon Crossword
 2022-05-13 Fixed problem with unchecking in limited check and check combinations

--- a/src/main/java/com/lorepo/icplayer/client/module/addon/AddonPresenter.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/addon/AddonPresenter.java
@@ -476,7 +476,8 @@ public class AddonPresenter implements IPresenter, IActivity, IStateful, IComman
 		boolean isVisible = !this.view.getElement().getStyle().getVisibility().equals("hidden") 
 				&& !this.view.getElement().getStyle().getDisplay().equals("none")
 				&& !KeyboardNavigationController.isParentGroupDivHidden(view.getElement());
-		return (isTextToSpeechOn || this.haveWCAGSupport(this.jsObject)) && isVisible;
+		boolean isEnabled = (!this.isDisabled()) || isTextToSpeechOn;
+		return (isTextToSpeechOn || this.haveWCAGSupport(this.jsObject)) && isVisible && isEnabled;
 	}
 	
 	@Override

--- a/src/main/java/com/lorepo/icplayer/client/module/button/ButtonPresenter.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/button/ButtonPresenter.java
@@ -259,7 +259,7 @@ public class ButtonPresenter implements IPresenter, IStateful, ICommandReceiver,
 	public boolean isSelectable(boolean isTextToSpeechOn) {
 		boolean isHidden = this.getView().getStyle().getVisibility().equals("hidden");
 		boolean isNone = this.getView().getStyle().getDisplay().equals("none");
-		boolean isEnabled = this.view.isEnabled();
+		boolean isEnabled = this.view.isEnabled() || isTextToSpeechOn;
 		boolean isGroupDivHidden  = KeyboardNavigationController.isParentGroupDivHidden(view.getElement());
 		
 		boolean isVisible = !isHidden && !isNone && isEnabled && !isGroupDivHidden;

--- a/src/main/java/com/lorepo/icplayer/client/module/choice/ChoicePresenter.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/choice/ChoicePresenter.java
@@ -803,7 +803,7 @@ public class ChoicePresenter implements IPresenter, IStateful, IOptionListener, 
 	@Override
 	public boolean isSelectable(boolean isTextToSpeechOn) {
 		boolean isVisible = !this.getView().getStyle().getVisibility().equals("hidden") && !this.getView().getStyle().getDisplay().equals("none");
-		boolean isEnabled = !this.module.isDisabled();
+		boolean isEnabled = (!this.module.isDisabled()) || isTextToSpeechOn;
 		boolean isGroupDivHidden = KeyboardNavigationController.isParentGroupDivHidden(view.getElement());
 		return isVisible && isEnabled && !isGroupDivHidden;
 	}

--- a/src/main/java/com/lorepo/icplayer/client/module/imagegap/ImageGapPresenter.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/imagegap/ImageGapPresenter.java
@@ -820,7 +820,7 @@ public class ImageGapPresenter implements IPresenter, IActivity, IStateful, ICom
 	@Override
 	public boolean isSelectable(boolean isTextToSpeechOn) {
 		boolean isVisible = !this.getView().getStyle().getVisibility().equals("hidden") && !this.getView().getStyle().getDisplay().equals("none");
-		boolean isEnabled = !this.model.isDisabled();
+		boolean isEnabled = (!this.model.isDisabled()) || isTextToSpeechOn;
 		boolean isGroupDivHidden = KeyboardNavigationController.isParentGroupDivHidden(view.getElement());
 		return isVisible && isEnabled && !isGroupDivHidden;
 	}

--- a/src/main/java/com/lorepo/icplayer/client/module/imagegap/ImageGapView.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/imagegap/ImageGapView.java
@@ -196,8 +196,10 @@ public class ImageGapView extends Image implements IDisplay, IWCAGModuleView, IW
 
 	@Override
 	public void space(KeyDownEvent event) {
-		event.preventDefault(); 
-		this.listener.onClicked();
+		event.preventDefault();
+		if (!module.isDisabled()) {
+			this.listener.onClicked();
+		}
 	}
 
 	@Override

--- a/src/main/java/com/lorepo/icplayer/client/module/imagesource/ImageSourcePresenter.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/imagesource/ImageSourcePresenter.java
@@ -488,7 +488,8 @@ public class ImageSourcePresenter implements IPresenter, IStateful, ICommandRece
 		final boolean isVisible = !this.getView().getStyle().getVisibility().equals("hidden") 
 				&& !this.getView().getStyle().getDisplay().equals("none")
 				&& !KeyboardNavigationController.isParentGroupDivHidden(view.getElement());
-		return isVisible && !this.view.getDisabled();
+		final boolean isEnabled = (!this.view.getDisabled()) || isTextToSpeechOn;
+		return isVisible && isEnabled;
 	}
 	
 	public String getAltText(){

--- a/src/main/java/com/lorepo/icplayer/client/module/imagesource/ImageSourceView.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/imagesource/ImageSourceView.java
@@ -239,7 +239,9 @@ public class ImageSourceView extends Image implements IDisplay, IWCAG, IWCAGModu
 	@Override
 	public void space(KeyDownEvent event) {
 		event.getNativeEvent().preventDefault();
-		this.listener.onClicked();
+		if (!module.isDisabled()) {
+			this.listener.onClicked();
+		}
 	}
 
 	@Override

--- a/src/main/java/com/lorepo/icplayer/client/module/limitedcheck/LimitedCheckPresenter.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/limitedcheck/LimitedCheckPresenter.java
@@ -375,6 +375,7 @@ public class LimitedCheckPresenter implements IPresenter, IStateful, ICommandRec
         boolean isVisible = !this.getView().getStyle().getVisibility().equals("hidden")
                 && !this.getView().getStyle().getDisplay().equals("none")
                 && !KeyboardNavigationController.isParentGroupDivHidden(view.getElement());
-        return isVisible;
+        boolean isEnabled = (!isDisabled()) || isTextToSpeechOn;
+        return isVisible && isEnabled;
     }
 }

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
@@ -1537,7 +1537,7 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
 		final boolean isVisible = !this.getView().getStyle().getVisibility().equals("hidden") && !this.getView().getStyle().getDisplay().equals("none");
 		final boolean isWithGaps = view.getChildrenCount() > 0;
 		final boolean hasLinks = module.getLinkInfos().iterator().hasNext();
-		final boolean isEnabled = !this.module.isDisabled();
+		final boolean isEnabled = (!this.module.isDisabled()) || isTextToSpeechOn;
 		final boolean isGroupDivHidden = KeyboardNavigationController.isParentGroupDivHidden(view.getElement());
 		return (isTextToSpeechOn || isWithGaps || hasLinks) && isVisible && isEnabled && !isGroupDivHidden;
 	}


### PR DESCRIPTION
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/8393--tts--nawigacja-tts-nie-wchodzi-w-addony-disable/details
Wersja testowa: https://test-8393-dot-mauthor-dev.ew.r.appspot.com/embed/4767302274777088