### PR TITLE
Fix color not being retained by the Text Coloring addon, re #8394

### DIFF
--- a/addons/Text_Coloring/src/presenter.js
+++ b/addons/Text_Coloring/src/presenter.js
@@ -1433,10 +1433,14 @@ function AddonText_Coloring_create() {
     };
 
     presenter.getState = function () {
+        var activeColorID = presenter.configuration.activeColorID;
+        if (!presenter.configuration.eraserMode && activeColorID === null) {
+            activeColorID = presenter.stateMachine.previousActiveColorID;
+        }
         return JSON.stringify({
             isVisible: presenter.configuration.isVisible,
             tokens: presenter.configuration.filteredTokens,
-            activeColorID: presenter.configuration.activeColorID
+            activeColorID: activeColorID
         });
     };
 

--- a/addons/Text_Coloring/src/presenter.js
+++ b/addons/Text_Coloring/src/presenter.js
@@ -1253,7 +1253,11 @@ function AddonText_Coloring_create() {
             presenter.configuration.activeColor = null;
         }
         presenter.disconnectWordTokensHandlers();
-        presenter.setColor(presenter.configuration.colors[0].id);
+        if  (presenter.stateMachine.previousActiveColorID !== null) {
+            presenter.setColor(presenter.stateMachine.previousActiveColorID);
+        } else {
+            presenter.setColor(presenter.configuration.colors[0].id);
+        }
     };
 
     presenter.setShowErrorsMode = function () {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2027-05-27 Fixed color not being retained by the Text Coloring addon if you leave the page in check answers mode
 2022-05-20 Block strict letters in Crossword
 2022-05-20 TTS keyboard navigation no longer ignores disabled addons
 2022-05-20 Add new property to CrossLesson addon - check access to cross lesson in LMS mCourser


### PR DESCRIPTION
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/8394-text-coloring---znikaj%C4%85ce-zaznaczenie-bie%C5%BC%C4%85cego-koloru/details
Wersja testowa: https://test-8394-dot-mauthor-dev.ew.r.appspot.com/embed/6704862081318912