### PR TITLE
fix(addon): Fixed Assessments Navigation Bar not adding inactive class re #8415

### DIFF
--- a/addons/Assessments_Navigation_Bar/src/presenter.js
+++ b/addons/Assessments_Navigation_Bar/src/presenter.js
@@ -693,8 +693,11 @@ function AddonAssessments_Navigation_Bar_create(){
     };
 
     presenter.NavigationManager.prototype.appendNavigationButtonsFirst = function () {
-        var $navigationButtonsFirst = $('<div></div>');
-        $navigationButtonsFirst.addClass("navigation-buttons-first");
+        const isFirstPage = presenter.currentPageIndex === 0;
+        const elementClass = isFirstPage ? "navigation-buttons-first inactive" : "navigation-buttons-first";
+
+        const $navigationButtonsFirst = $('<div></div>');
+        $navigationButtonsFirst.addClass(elementClass);
 
         this.navigationButtonLeft = new presenter.NavigationButtonLeft();
         $navigationButtonsFirst.append(this.navigationButtonLeft.getView());
@@ -704,8 +707,11 @@ function AddonAssessments_Navigation_Bar_create(){
     };
 
     presenter.NavigationManager.prototype.appendNavigationButtonsLast = function () {
-        var $navigationButtonsLast = $('<div></div>');
-        $navigationButtonsLast.addClass("navigation-buttons-last");
+        const isLastPage = presenter.currentPageIndex === presenter.configuration.numberOfPages - 1;
+        const elementClass = isLastPage ? "navigation-buttons-last inactive" : "navigation-buttons-last";
+
+        const $navigationButtonsLast = $('<div></div>');
+        $navigationButtonsLast.addClass(elementClass);
 
         this.navigationButtonRight = new presenter.NavigationButtonRight();
         $navigationButtonsLast.append(this.navigationButtonRight.getView());

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2022-06-02 Fixed Assessments Navigation Bar not adding "inactive" class
 2022-05-27 Fixed NextPageButton and PrevPageButton triggering click twice on moodle on iOS
 2022-05-24 Fix display ZoomImage in mobile
 2022-05-24 Fix Drawing.uploadImage command not working on Safari iOS


### PR DESCRIPTION
[Lekcja testowa](https://test-8415-dot-mauthor-dev.ew.r.appspot.com/embed/5919288470798336)
[Ticket](https://learneticsa.assembla.com/spaces/lorepo/tickets/8415--pearson--assessments-navigation-bar-nie-dodaje-klasy-inactive/details)