### PR TITLE
Test 8484

### DIFF
--- a/addons/Hierarchical_Table_Of_Contents/src/addon.xml
+++ b/addons/Hierarchical_Table_Of_Contents/src/addon.xml
@@ -3,6 +3,7 @@
     <model>
         <property name="titleLabel" displayName="Title label" nameLabel="Hierarchical_Table_Of_Contents_property_title_label" type="string" isLocalized="true" />
         <property name='displayOnlyChapters' displayName="Display only chapters" nameLabel="Hierarchical_Table_Of_Contents_property_display_only_chapters" type='boolean'/>
+        <property name="expandDepth" displayName="Depth of expand" nameLabel="Hierarchical_Lesson_Report_property_expand_depth" type="string" />
         <property name="showPages" displayName="Show Pages" nameLabel="Hierarchical_Table_Of_Contents_property_show_pages" type="{All, Reportable, Not-reportable}" isLocalized="true" />
         <property name="langAttribute" displayName="Lang attribute" nameLabel="Hierarchical_Table_Of_Contents_property_lang_attribute" type="string" />
         <property name="speechTexts" displayName="Speech texts" nameLabel="Hierarchical_Table_Of_Contents_property_speech_texts" type="staticlist">

--- a/addons/Hierarchical_Table_Of_Contents/src/presenter.js
+++ b/addons/Hierarchical_Table_Of_Contents/src/presenter.js
@@ -7,6 +7,7 @@ function AddonHierarchical_Table_Of_Contents_create() {
     presenter.keyboardControllerObject = null;
 
     presenter.ERROR_MESSAGES = {
+        EXPAND_DEPTH_NOT_NUMERIC: "Depth of expand is not proper",
     };
 
     presenter.CSS_CLASSES = {
@@ -252,6 +253,28 @@ function AddonHierarchical_Table_Of_Contents_create() {
     };
 
     presenter.validateModel = function (model) {
+        var expandDepth = returnCorrectObject(0);
+        if (model['expandDepth'].length > 0) {
+            expandDepth = ModelValidationUtils.validateInteger(model['expandDepth']);
+            if (!expandDepth.isValid) {
+                return returnErrorObject('EXPAND_DEPTH_NOT_NUMERIC');
+            }
+        }
+        var obj = {
+            ID: model.ID,
+            isValid: true,
+            width: parseInt(model["Width"], 10),
+            height: parseInt(model["Height"], 10),
+            isVisible: ModelValidationUtils.validateBoolean(model["Is Visible"]),
+            labels: {
+                title: model['titleLabel']
+            },
+            displayOnlyChapters: ModelValidationUtils.validateBoolean(model.displayOnlyChapters),
+            expandDepth: expandDepth.value,
+            showPages: model.showPages,
+            langTag: model.langAttribute,
+        };
+        console.log(obj);
         return {
             ID: model.ID,
             isValid: true,
@@ -262,6 +285,7 @@ function AddonHierarchical_Table_Of_Contents_create() {
                 title: model['titleLabel']
             },
             displayOnlyChapters: ModelValidationUtils.validateBoolean(model.displayOnlyChapters),
+            expandDepth: expandDepth.value,
             showPages: model.showPages,
             langTag: model.langAttribute,
         };

--- a/addons/Hierarchical_Table_Of_Contents/src/presenter.js
+++ b/addons/Hierarchical_Table_Of_Contents/src/presenter.js
@@ -260,21 +260,6 @@ function AddonHierarchical_Table_Of_Contents_create() {
                 return returnErrorObject('EXPAND_DEPTH_NOT_NUMERIC');
             }
         }
-        var obj = {
-            ID: model.ID,
-            isValid: true,
-            width: parseInt(model["Width"], 10),
-            height: parseInt(model["Height"], 10),
-            isVisible: ModelValidationUtils.validateBoolean(model["Is Visible"]),
-            labels: {
-                title: model['titleLabel']
-            },
-            displayOnlyChapters: ModelValidationUtils.validateBoolean(model.displayOnlyChapters),
-            expandDepth: expandDepth.value,
-            showPages: model.showPages,
-            langTag: model.langAttribute,
-        };
-        console.log(obj);
         return {
             ID: model.ID,
             isValid: true,

--- a/addons/Hierarchical_Table_Of_Contents/test/ModelValidationTests.js
+++ b/addons/Hierarchical_Table_Of_Contents/test/ModelValidationTests.js
@@ -1,0 +1,45 @@
+TestCase("[Hierarchical Table Of Contents] Model validation", {
+    setUp: function () {
+        this.presenter = AddonHierarchical_Table_Of_Contents_create();
+
+        this.model = {
+            ID: "Hierarchical_Table_Of_Contents1",
+            isValid: "True",
+            IsVisible: "True",
+            displayOnlyChapters: "false",
+            expandDepth: "",
+            height: "275",
+            width: "300",
+            titleLabel: "Table of Contents",
+            langTag: "",
+            showPages: "",
+        };
+    },
+
+    'test depth of expand empty': function () {
+        this.model["expandDepth"] = "";
+
+        var validationResult = this.presenter.validateModel(this.model);
+
+        assertTrue(validationResult.isValid);
+        assertEquals('0', validationResult.expandDepth);
+    },
+
+    'test depth of expand correct': function () {
+        this.model["expandDepth"] = "1";
+
+        var validationResult = this.presenter.validateModel(this.model);
+
+        assertTrue(validationResult.isValid);
+        assertEquals('1', validationResult.expandDepth);
+    },
+
+    'test depth of expand not numeric': function () {
+        this.model["expandDepth"] = "a";
+
+        var validationResult = this.presenter.validateModel(this.model);
+
+        assertFalse(validationResult.isValid);
+        assertEquals('EXPAND_DEPTH_NOT_NUMERIC', validationResult.errorCode);
+    }
+});

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2022-07-21 Added Depth Of Expand property to Hierarchical Table Of Contents
 2022-07-12 Upgraded Zoom Image destroy to close module when changing layout
 2022-07-12 Fixed ANB not adding "inactive" class
 2022-07-11 Added new property Page has not been reset to the Reset Button speech text


### PR DESCRIPTION
Ticket:
https://learneticsa.assembla.com/spaces/lorepo/tickets/8484-hierarchical-table-of-contents---dodanie-depth-of-expand/details

Wersja testowa:
https://test-8484-dot-mauthor-dev.ew.r.appspot.com/

Lekcja testowa:
https://test-8484-dot-mauthor-dev.ew.r.appspot.com/embed/5680236496683008

W lekcji testowej ustawiono Depth of Expand na 2, dlatego rozwija się wszystko z wyjątkiem rozdziału 2.1.1
