### PR TITLE
fix(addons): Fixed Double State Button not calling events when placed in dynamic dom elements re #8453

### DIFF
--- a/addons/Double_State_Button/src/presenter.js
+++ b/addons/Double_State_Button/src/presenter.js
@@ -150,7 +150,7 @@ function AddonDouble_State_Button_create(){
 
         $element.on('mousedown', (e) => mouseDownEventHandler(e));
         $element.on('click', (e) => clickEventHandler(e));
-		$element.on('mouseup', (e) => mouseUpEventHandler(e));
+        $element.on('mouseup', (e) => mouseUpEventHandler(e));
 
         $element.hover(
             function() {

--- a/addons/Double_State_Button/src/presenter.js
+++ b/addons/Double_State_Button/src/presenter.js
@@ -146,13 +146,13 @@ function AddonDouble_State_Button_create(){
     }
 
     function handleMouseActions() {
-        var element = presenter.$view.find('div[class*=doublestate-button-element]:first');
+        const $element = presenter.$view.find('div[class*=doublestate-button-element]:first');
 
-        element.on('mousedown', mouseDownEventHandler);
-        element.on('click', clickEventHandler);
-		element.on('mouseup', mouseUpEventHandler);
+        $element.on('mousedown', (e) => mouseDownEventHandler(e));
+        $element.on('click', (e) => clickEventHandler(e));
+		$element.on('mouseup', (e) => mouseUpEventHandler(e));
 
-        element.hover(
+        $element.hover(
             function() {
                 $(this).removeClass(CSS_CLASSESToString());
                 $(this).addClass(presenter.isSelected() ? CSS_CLASSES.SELECTED_MOUSE_HOVER : CSS_CLASSES.MOUSE_HOVER);

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2022-07-25 Fixed Double State Button not calling events when placed in dynamic dom elements
 2022-07-19 Fixed direct cross-origin calls in several places in the app
 2022-07-15 Added TTS support to Magic Boxes
 2022-07-15 Changed Cross Lesson model validation to allow check only by LessonID


### PR DESCRIPTION
[Ticket](https://learneticsa.assembla.com/spaces/lorepo/tickets/8453--dsb--button-osadzony-w-dynamicznie-utworzonym--lt-div-gt--nie-wysy%C5%82a-eventu/details)
[Wersja testowa](https://test-8453-dot-mauthor-dev.ew.r.appspot.com/present/5634844597944320)