### PR TITLE
Added page_id to paginated score, re #8510

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2022-08-10 Added page_id to paginated score
 2022-08-05 Removed static editor notification
 2022-08-05 Fixed getActivitiesCount method in Connection
 2022-08-05 Added IsNotActivity property to Puzzle

--- a/src/main/java/com/lorepo/icplayer/public/libs/player-utils.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/player-utils.js
@@ -78,6 +78,7 @@
                     paginatedResults[count] = {
                         "page_number": (i + 1),
                         "page_name": page.getName(),
+                        "page_id": page.getId(),
                         "score": Math.round(pageScaledScore * 100) / 100,
                         "absolute_score": score['score'],
                         "max_score": score['maxScore'],


### PR DESCRIPTION
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/8510-dodanie-page_id-do-wyniku-metody-getpresentationscore/details
Wersja testowa: https://test-8510-dot-mauthor-dev.ew.r.appspot.com/

testowanie:
W konsoli należy wywołać

var utils = new window.PlayerUtils(player);
var presentation = utils.getPresentation();
var score = utils.getPresentationScore(presentation);

W score w elementach tablicy paginatedResults powinno pojawić się nowe pole page_id.