### PR TITLE
Fix the CSS class in AudioPlaylist breaking the appearance of addon, re #8511

### DIFF
--- a/addons/AudioPlaylist/src/style.css
+++ b/addons/AudioPlaylist/src/style.css
@@ -13,7 +13,6 @@
 
 div.addon-audio-playlist-controls {
     padding: 10px 25px;
-    height: 40px;
     position: relative;
     border: 1px solid black;
     border-radius: 30px;
@@ -38,7 +37,6 @@ button.audio-playlist-control-btn {
     cursor: pointer;
     border: 0;
     background-color: white;
-
 }
 
 button.audio-playlist-next-btn {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2022-08-11 Fixed the CSS class in AudioPlaylist breaking the appearance of addon
 2022-08-10 Added page_id to paginated score
 2022-08-05 Removed static editor notification
 2022-08-05 Fixed getActivitiesCount method in Connection


### PR DESCRIPTION
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/8511-przesuniecia-w-contencie-i-playerze-pod-win--mac-os--android---layout-w-le/details
Lekcja testowa: https://test-ml2-53-dot-mauthor-dev.ew.r.appspot.com/embed/5747281791811584

Jak przetestować:
Używając konsoli przeglądarki należy zaznaczyć `div` z klasą `addon-audio-playlist-controls`. Klasa na tym elemencie nie powinna mieć ustawionej wysokości.