### PR TITLE
fix(addons): Fix Media Recorder height on mLibro

### DIFF
--- a/addons/Media_Recorder/src/style.css
+++ b/addons/Media_Recorder/src/style.css
@@ -13,7 +13,7 @@
 
 .media-recorder-wrapper .media-recorder-interface-wrapper {
     width: 300px;
-    height: 40px;
+    min-height: 40px;
     display: flex;
     align-items: center;
     background-color: #EBEFF0;

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,3 @@
-2022-08-11 Added GSA support to Magic Boxes
 2022-08-11 Fixed the CSS class in AudioPlaylist breaking the appearance of addon
 2022-08-05 Removed static editor notification
 2022-08-05 Fixed getActivitiesCount method in Connection


### PR DESCRIPTION
[Ticket](https://learneticsa.assembla.com/spaces/lorepo/tickets/8511-przesuniecia-w-contencie-i-playerze-pod-win--mac-os--android---layout-w-le/details)