### PR TITLE
Fixing keyboard navigation throught link gaps #8489

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2022-08-17 Fixed keyboard navigation throught link gaps
 2022-08-11 Added GSA support to Magic Boxes
 2022-08-11 Fixed the CSS class in AudioPlaylist breaking the appearance of addon
 2022-08-05 Removed static editor notification

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
@@ -36,6 +36,7 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 	private final ArrayList<String> mathGapIds = new ArrayList<String>();
 	private boolean moduleHasFocus = false;
 	private int activeGapIndex = -1;
+	private int activeNavigationGapIndex = -1; //to distinct the active index of navigation text elements (includes links)
 	private TextElementDisplay activeGap = null;
 	private PageController pageController;
 	private ArrayList<InlineChoiceInfo> inlineChoiceInfoArrayList = new ArrayList<InlineChoiceInfo>();
@@ -518,6 +519,7 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 	private void handleWCAGExit() {
         this.removeNavigationElementSelections();
         activeGapIndex = -1;
+        activeNavigationGapIndex = -1;
         activeGap = null;
         moduleHasFocus = false;
 	}
@@ -559,7 +561,7 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 		}
 		
 		this.removeNavigationElementSelections();
-		int nextGapIndex = goNext ? activeGapIndex + 1 : activeGapIndex - 1;
+		int nextGapIndex = goNext ? activeNavigationGapIndex + 1 : activeNavigationGapIndex - 1;
 
 		if (nextGapIndex >= size) {
 			nextGapIndex = size - 1;
@@ -571,10 +573,15 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 		}
 
 		NavigationTextElement activeElement = navigationTextElements.get(nextGapIndex);
-		if (!(activeElement instanceof LinkWidget)) {
-			if (goNext && !hasAchievedMaximum) {
+		if (goNext && !hasAchievedMaximum) {
+			activeNavigationGapIndex++;
+			if (!(activeElement instanceof LinkWidget)) {
 				focusOnNextGap();
-			} else if (!goNext && activeGapIndex > 0) {
+			}
+			
+		} else if (!goNext && activeNavigationGapIndex > 0) {
+			activeNavigationGapIndex--;
+			if (!(activeElement instanceof LinkWidget)) {
 				focusOnPrevGap();
 			}
 		}


### PR DESCRIPTION
[Ticket](https://learneticsa.assembla.com/spaces/lorepo/tickets/8489-text-+-link---key-nav-nie-przechodzi-poprawnie-po-gapach-/details?tab=activity#)
[Przykładowa lekcja](https://test-8489-dot-mauthor-dev.ew.r.appspot.com/embed/5678862560133120)
[Wersja testowa](https://test-8489-dot-mauthor-dev.ew.r.appspot.com)