### PR TITLE
Fix displaying answers in Figure Drawing #8493

### DIFF
--- a/addons/FigureDrawing/src/presenter.js
+++ b/addons/FigureDrawing/src/presenter.js
@@ -5,6 +5,7 @@ function AddonFigureDrawing_create(){
     presenter.isStarted = false;
     presenter.isErrorMode = false;
     presenter.isShowAnswersActive = false;
+    presenter.wasShowAnswersActive = false;
     presenter.executeCommand = function(name, params) {
         switch(name.toLowerCase()) {
             case 'hide'.toLowerCase():
@@ -1011,6 +1012,7 @@ function AddonFigureDrawing_create(){
 
     presenter.getErrorCount = function(){
         var errorCounter = 0, i, lineCounter, color;
+        presenter.wasShowAnswersActive = presenter.isShowAnswersActive;
         if (presenter.isShowAnswersActive) presenter.hideAnswers();
         if (presenter.activity && !presenter.error && presenter.isStarted) {
             errorCounter = presenter.$view.find('.line').not('.nonremovable').length;
@@ -1033,16 +1035,20 @@ function AddonFigureDrawing_create(){
                 }
             }
         }
+        if(presenter.wasShowAnswersActive) presenter.showAnswers();
         return errorCounter;
     }
     presenter.getMaxScore = function(){
+        var maxScore = 0;
+        presenter.wasShowAnswersActive = presenter.isShowAnswersActive;
         if (presenter.isShowAnswersActive) presenter.hideAnswers();
         if (presenter.activity && !presenter.error && presenter.coloring)
-            return (presenter.AnswerLines.length + presenter.answersColors.length)
+            maxScore = presenter.AnswerLines.length + presenter.answersColors.length;
         else if (presenter.activity && !presenter.error)
-            return (presenter.AnswerLines.length)
-        else
-            return 0;
+            maxScore = presenter.AnswerLines.length;
+
+        if(presenter.wasShowAnswersActive) presenter.showAnswers();
+        return maxScore;
     }
     presenter.getScore = function(){
         if (presenter.activity && !presenter.error && presenter.isStarted) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2022-08-17 Fixed displaying answers in Figure Drawing
 2022-08-11 Added GSA support to Magic Boxes
 2022-08-11 Fixed the CSS class in AudioPlaylist breaking the appearance of addon
 2022-08-05 Removed static editor notification


### PR DESCRIPTION
[Ticket](https://app.assembla.com/spaces/lorepo/tickets/8493-nie-dzia%C5%82a-show-answers-dla-figure-drawing-gdy-jest-controller-(custom-ad/details#)
[Wersja testowa](https://test-8493-dot-mauthor-dev.ew.r.appspot.com)
[Przykładowa lekcja](https://test-8493-dot-mauthor-dev.ew.r.appspot.com/embed/6430265410846720#4)