### PR TITLE
Fix GSA functionality for empty answers model in the Paragraph 8518

### DIFF
--- a/addons/Paragraph/src/presenter.js
+++ b/addons/Paragraph/src/presenter.js
@@ -164,10 +164,6 @@ function AddonParagraph_create() {
         }
     };
 
-    presenter.getActivitiesCount = function () {
-        return 1;
-    }
-
     presenter.enableEdit = function () {
         let paragraph = presenter.$view.find(".paragraph-wrapper");
 
@@ -1280,7 +1276,13 @@ function AddonParagraph_create() {
     };
 
     presenter.getActivitiesCount = function Paragraph_getActivitiesCount () {
-        return presenter.configuration.modelAnswer.length;
+        let answersCount = 0;
+        presenter.configuration.modelAnswer.forEach(answer => {
+            if (answer.Text.replace("<br>", "") !== "") {
+                answersCount++;
+            }
+        });
+        return answersCount;
     };
 
     return presenter;

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2022-08-29 Fixed GSA functionality for empty model answers in the Paragraph
 2022-08-25 Fixed outstretchHeight command not working properly with layout argument
 2022-08-19 Fixed keyboard navigation throught link gaps
 2022-08-19 Updated setGapText method to fix indexation


### PR DESCRIPTION
[Ticket](https://learneticsa.assembla.com/spaces/lorepo/tickets/8518--paragraph--zmiana-funkcjonalno%C5%9Bci-gsa---pomijanie-paragraph--gdy-property--q/details?comment=1701320200#)
[Wersja testowa](https://test-8518-dot-mauthor-dev.ew.r.appspot.com)
[Przykładowa lekcja](https://test-8518-dot-mauthor-dev.ew.r.appspot.com/embed/5988630902341632)