### PR TITLE
Fix inability to drag a Source List item from Text when formatting is used, re #8638

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2023-01-12 Fixed inability to drag a Source List item from Text when formatting is used
 2023-01-09 Fixed player not handling empty getState, getScore, getMaxScore, getErrorsCount methods in addons
 2023-01-09 Expanded support for alternative texts in editable window
 2023-01-09 Added functionality to use weighted arithmetic mean in Hierarchical lesson report addon

--- a/src/main/java/com/lorepo/icplayer/client/module/text/DraggableGapWidget.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/DraggableGapWidget.java
@@ -222,7 +222,7 @@ public class DraggableGapWidget extends HTML implements TextElementDisplay, AltT
 
 			super.setHTML(visibleText);
 			answerText = TextParser.removeHtmlFormatting(visibleText);
-			droppedElementHelper = getElement(visibleText);
+			droppedElementHelper = getElement(answerText);
 			setStylePrimaryName(FILLED_GAP_STYLE);
 			if (!droppedElementHelper.isEmpty() && !isShowAnswersMode){
 				JavaScriptUtils.makeDroppedDraggableText(this.getElement(), getAsJavaScript(), droppedElementHelper);


### PR DESCRIPTION
[Ticket](https://learneticsa.assembla.com/spaces/lorepo/tickets/8638--aga--sourcelist---nie-mo%C5%BCna-wydragowa%C4%87-elementu-z-gapy/details)
[Wersja testowa](https://test-8638-dot-mauthor-dev.ew.r.appspot.com)
[Lekcja testowa](https://test-8638-dot-mauthor-dev.ew.r.appspot.com/embed/4864631149428736)