### PR TITLE
fix(addons): Fix connection not coloring connections with MathJax re #8643

### DIFF
--- a/addons/Connection/src/presenter.js
+++ b/addons/Connection/src/presenter.js
@@ -36,6 +36,7 @@ function AddonConnection_create() {
     presenter.printableParserID = "";
     presenter.printableParserCallback = null;
 
+    // Komentarz do usunięcia w zadaniu 8643 - Jest szansa, że zmiana ustawienia stanu mathJaxLoaders i kilka warunków naprawi problem.
     presenter.mathJaxLoaders = {
         runLoader: false,
         setStateLoader: true
@@ -358,15 +359,18 @@ function AddonConnection_create() {
     };
 
     presenter.registerMathJax = function AddonConnection_registerMathJax() {
+        console.log("Execute presenter.registerMathJax");
         var mathJaxDeferred = new jQuery.Deferred();
         presenter.mathJaxProcessEndedDeferred = mathJaxDeferred;
         presenter.mathJaxProcessEnded = mathJaxDeferred.promise();
 
         MathJax.Hub.Register.MessageHook("End Process", function (message) {
             if ($(message[1]).hasClass('ic_page')) {
+                console.log("Resolve mathJaxProcessEndedDeferred ic_page");
                 presenter.mathJaxProcessEndedDeferred.resolve();
             }
             if ($(message[1]).hasClass('ic_popup_page')) {
+                console.log("Resolve mathJaxProcessEndedDeferred ic_popup_page");
                 presenter.mathJaxProcessEndedDeferred.resolve();
             }
         });
@@ -578,6 +582,7 @@ function AddonConnection_create() {
     };
 
     presenter.initialize = function (view, model, isPreview) {
+        console.log("Execute initialize");
         if (isPreview) {
             presenter.lineStack = new LineStack(false);
         }
@@ -663,6 +668,7 @@ function AddonConnection_create() {
             presenter.removeNonVisibleInnerHTML();
         } else {
             presenter.mathJaxProcessEnded.then(function () {
+                console.log("presenter.mathJaxProcessEnded in presenter.initialize");
                 waitForLoad($connectionContainer, () => {
                     presenter.initializeView(view, model);
                     presenter.drawInitialValues();
@@ -1438,6 +1444,7 @@ function AddonConnection_create() {
 
     presenter.setShowErrorsMode = deferredCommandQueue.decorate(
         function () {
+            console.log("Execute callback from presenter.setShowErrorsMode");
             presenter.isCheckActive = true;
             if (presenter.isShowAnswersActive) {
                 presenter.hideAnswers();
@@ -1445,15 +1452,19 @@ function AddonConnection_create() {
             if (presenter.isNotActivity) return 0;
 
             connections.clearCanvas();
+            console.log("presenter.correctConnections", presenter.correctConnections);
+            console.log("presenter.lineStack", presenter.lineStack);
             for (var i = 0; i < presenter.lineStack.length(); i++) {
                 var line = presenter.lineStack.get(i);
                 if (presenter.correctConnections.hasLine(line).length > 0) {
+                    console.log("line", line, "draw as correct");
                     drawLine(presenter.lineStack.get(i), correctConnection);
                     var fromElementCorrect = $(presenter.view).find('#' + presenter.lineStack.get(i).from[0].id);
                     var toElementCorrect = $(presenter.view).find('#' + presenter.lineStack.get(i).to[0].id);
                     $(fromElementCorrect).addClass(CORRECT_ITEM_CLASS);
                     $(toElementCorrect).addClass(CORRECT_ITEM_CLASS);
                 } else {
+                    console.log("line", line, "draw as wrong");
                     drawLine(presenter.lineStack.get(i), incorrectConnection);
                     var fromElementIncorrect = $(presenter.view).find('#' + presenter.lineStack.get(i).from[0].id);
                     var toElementIncorrect = $(presenter.view).find('#' + presenter.lineStack.get(i).to[0].id);
@@ -1636,12 +1647,15 @@ function AddonConnection_create() {
     };
 
     presenter.setState = function (state) {
+        console.log("executed setState");
         var hookExecuted = false;
         presenter.initialState = state;
         presenter.mathJaxLoaders.setStateLoader = false;
 
         presenter.mathJaxProcessEnded.then(function () {
+            console.log("presenter.mathJaxProcessEnded in setState");
             if (state !== '' && !hookExecuted) {
+                console.log("create connected lines in setState");
                 presenter.lineStack.setSendEvents(false);
                 presenter.lineStack.clear();
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2023-02-03 Fixed connection not coloring connections with MathJax
 2023-01-24 Fixed functionality to auto set in correct order groups' modules in view
 2023-01-20 Added support to audio events in Text addon
 2023-01-20 Added support for more than one digit inside the gap in Writing calculation addon


### PR DESCRIPTION
[Lekcja testowa](https://test-8643-dot-mauthor-dev.ew.r.appspot.com/embed/5947552136429568#2)
[Ticket](https://learneticsa.assembla.com/spaces/lorepo/tickets/8643--aga--connection---check-na-powr%C3%B3t-na-stron%C4%99-ipad/details)

Opis:
Niektóre metody w Connection w zamyśle mają odpalić się dopiero po załadowaniu różnych elementów tego addonu - np. obrazków albo MathJax'a. Do osiągnięcia tego celu stosowano m.in. `deferredCommandQueue`. 

Okazało się, że  `deferredCommandQueue` była odblokowywana w złym miejscu, bez upewnienia się, że wszystkie asynchroniczne operacje które uprzednio powinny się wykonać, faktycznie się wykonały. To powodowało wykonanie się operacji w złej kolejności, oraz błąd z ticketu. 
Zagadką jest dla mnie dlaczego działało to na desktopie :P 