### PR TITLE
Change behavior of the Assessments Navigation Bar addon to reset attempted status after receiving Lesson Reset event, re #8715

### DIFF
--- a/addons/Assessments_Navigation_Bar/src/presenter.js
+++ b/addons/Assessments_Navigation_Bar/src/presenter.js
@@ -293,6 +293,10 @@ function AddonAssessments_Navigation_Bar_create(){
         this.$view.removeClass(presenter.CSS_CLASSES.BOOKMARK);
     };
 
+    presenter.Button.prototype.removeAttempted = function () {
+        this.$view.removeClass(presenter.CSS_CLASSES.ALL_ATTEMPTED);
+    };
+
     presenter.Button.prototype.createView = function () {
         var $view = $('<div></div>');
 
@@ -447,6 +451,10 @@ function AddonAssessments_Navigation_Bar_create(){
         if (attempted_page_index !== -1) {
             this.attemptedPages.splice(attempted_page_index, 1);
         }
+    };
+
+    presenter.Sections.prototype.markAllPagesAsNotAttempted = function () {
+        this.attemptedPages = [];
     };
 
     presenter.Sections.prototype.getPagesIndexes = function (pages) {
@@ -660,6 +668,15 @@ function AddonAssessments_Navigation_Bar_create(){
         }).forEach(function (button) {
             button.addCssClass(presenter.CSS_CLASSES.ALL_ATTEMPTED);
         });
+    };
+
+    presenter.NavigationManager.prototype.removeAttemptedFromButtons = function () {
+        this.buttons.forEach(function(button) {
+            button.removeAttempted();
+        });
+        this.sections.map(function (section) {
+            section.markAllPagesAsNotAttempted();
+        })
     };
 
     presenter.NavigationManager.prototype.initView = function () {
@@ -1711,6 +1728,7 @@ function AddonAssessments_Navigation_Bar_create(){
         }
         if (eventData.item === "Lesson Reset") {
             presenter.navigationManager.removeBookmarksFromButtons();
+            presenter.navigationManager.removeAttemptedFromButtons();
         }
     };
 

--- a/addons/Assessments_Navigation_Bar/src/presenter.js
+++ b/addons/Assessments_Navigation_Bar/src/presenter.js
@@ -674,9 +674,7 @@ function AddonAssessments_Navigation_Bar_create(){
         this.buttons.forEach(function(button) {
             button.removeAttempted();
         });
-        if (presenter.sections) {
-            presenter.sections.markAllPagesAsNotAttempted();
-        }
+        presenter.sections.markAllPagesAsNotAttempted();
     };
 
     presenter.NavigationManager.prototype.initView = function () {

--- a/addons/Assessments_Navigation_Bar/src/presenter.js
+++ b/addons/Assessments_Navigation_Bar/src/presenter.js
@@ -674,9 +674,7 @@ function AddonAssessments_Navigation_Bar_create(){
         this.buttons.forEach(function(button) {
             button.removeAttempted();
         });
-        this.sections.map(function (section) {
-            section.markAllPagesAsNotAttempted();
-        })
+        this.sections.markAllPagesAsNotAttempted();
     };
 
     presenter.NavigationManager.prototype.initView = function () {

--- a/addons/Assessments_Navigation_Bar/src/presenter.js
+++ b/addons/Assessments_Navigation_Bar/src/presenter.js
@@ -674,7 +674,9 @@ function AddonAssessments_Navigation_Bar_create(){
         this.buttons.forEach(function(button) {
             button.removeAttempted();
         });
-        this.sections.markAllPagesAsNotAttempted();
+        if (presenter.sections) {
+            presenter.sections.markAllPagesAsNotAttempted();
+        }
     };
 
     presenter.NavigationManager.prototype.initView = function () {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2022-03-21 Changed behavior of the Assessments Navigation Bar addon to reset attempted status after receiving Lesson Reset event
 2022-03-10 Added autofill page id button in editor
 2023-03-10 Added new property TTS Title to the addons
 2023-03-08 Changed behavior of isAttempted command if placeholder is set in paragraph addons


### PR DESCRIPTION
[Ticket](https://learneticsa.assembla.com/spaces/lorepo/tickets/8715-anb---po-lesson-reset-nadal-jest-all-attempted/details)
[Wersja testowa](https://test-8715-dot-mauthor-dev.ew.r.appspot.com/)
[Lekcja testowa](https://test-8715-dot-mauthor-dev.ew.r.appspot.com/present/6181860386275328#4)