### PR TITLE
Fix print of text coloring when color ID is not equal to color description, re #8717

### DIFF
--- a/addons/Text_Coloring/src/presenter.js
+++ b/addons/Text_Coloring/src/presenter.js
@@ -1615,20 +1615,28 @@ function AddonText_Coloring_create() {
         var areAllSelectable = presenter.configuration.mode === 'ALL_SELECTABLE'
 
         modelText.forEach((token, index) => {
+            var colorId;
+            var color;
             switch (true) {
                 case (userAnswer && userAnswer[index].isSelected) && !showAnswers:
-                    var color = parseToGrayscale(presenter.getColorInHex(model, userAnswer[index].selectionColorID));
+                    colorId = userAnswer[index].selectionColorID;
+                    color = presenter.getColor(model, colorId);
+
                     printableHTML += `<span style="border: 2px solid ${color}">${userAnswer[index].value}</span> `;
                     break;
 
                 case (userAnswer && userAnswer[index].isSelected) && showAnswers:
-                    var color = parseToGrayscale(presenter.getColorInHex(model, userAnswer[index].selectionColorID));
+                    colorId = userAnswer[index].selectionColorID;
+                    color = presenter.getColor(model, colorId);
+
                     var answerMark = presenter.isAnswerCorrect(userAnswer[index], token.value) ? '&#10004;' : '&#10006;';
                     printableHTML += `<span style="border: 2px solid ${color}">${userAnswer[index].value} ${answerMark}</span> `;
                     break;
 
                 case token.hasOwnProperty('color') && showAnswers && !didUserAnswer:
-                    var color = presenter.getColor(model, token.color);
+                    colorId = token.color;
+                    color = presenter.getColor(model, colorId);
+
                     printableHTML += `<span style="border: 2px dashed ${color}">${token.value}</span> `;
                     break;
 
@@ -1675,17 +1683,17 @@ function AddonText_Coloring_create() {
     presenter.getColors = function (model) {
         var colors = [];
         model['colors'].forEach(colorObject => {
-           colors.push({name: colorObject.description, value: parseToGrayscale(colorObject.color)});
+           colors.push({id: colorObject.id, value: parseToGrayscale(colorObject.color)});
         });
 
         return colors;
     }
 
     /* Returns color in hex code from color name */
-    presenter.getColorInHex = function (model, colorName) {
+    presenter.getColorInHex = function (model, colorId) {
         var colors =  presenter.getColors(model);
 
-        return colors.find(color => color.name === colorName).value;
+        return colors.find(color => color.id === colorId).value;
     }
 
     /* Extracts the word from phrase \\color{color}{word} */
@@ -1695,8 +1703,8 @@ function AddonText_Coloring_create() {
     }
 
     /* Extracts the color from phrase and convert into grayscale \\color{color}{word} */
-    presenter.getColor = function (model, color) {
-        return parseToGrayscale(presenter.getColorInHex(model, color));
+    presenter.getColor = function (model, colorId) {
+        return parseToGrayscale(presenter.getColorInHex(model, colorId));
     }
 
     /* Return user answers */

--- a/addons/Text_Coloring/src/presenter.js
+++ b/addons/Text_Coloring/src/presenter.js
@@ -519,9 +519,9 @@ function AddonText_Coloring_create() {
             presenter.connectHandlers();
             presenter.setColor(presenter.configuration.colors[0].id);
             presenter.stateMachine.notifyEdit();
+            presenter.buildKeyboardController();
+            presenter.setSpeechTexts(model["speechTexts"]);
         }
-        presenter.buildKeyboardController();
-        presenter.setSpeechTexts(model["speechTexts"]);
     };
 
     presenter.createStateMachine = function() {

--- a/addons/Text_Coloring/test/ModelValidationTests.js
+++ b/addons/Text_Coloring/test/ModelValidationTests.js
@@ -253,22 +253,22 @@ TestCase("[Text_Coloring] Model Validation flow", {
         var eraserButtonText = "Argh";
 
         var expectedModel = {
-            isVisible: true,
+            ID: modelID,
             isValid: true,
             isError: false,
-            ID: modelID,
-            colors: colorsValue,
             textTokens: parsedText,
+            colors: colorsValue,
             buttonsPosition: buttonsPosition,
             showAllAnswersInGradualShowAnswersMode: false,
             showSetEraserButtonMode: false,
             hideColorsButtons: false,
             eraserButtonText: eraserButtonText,
+            isVisible: true,
             mode: "MARK_PHRASES",
             countErrors: false,
             modelText: ['Example', 'text'],
             height: 50,
-            legendTitle: "Legend"
+            legendTitle: "Legend",
         };
 
         this.stubs.validateColors.returns({
@@ -292,8 +292,10 @@ TestCase("[Text_Coloring] Model Validation flow", {
             Height: 100
         });
 
-
-        assertEquals(expectedModel, result);
+        Object.keys(expectedModel).forEach(function(key, index) {
+            assertEquals(expectedModel[key], result[key]);
+        });
+        assertEquals(expectedModel.length, result.length);
         assertTrue(this.stubs.validateColors.calledOnce);
         assertTrue(this.stubs.parseText.calledOnce);
     }

--- a/addons/Text_Coloring/test/PrintHTMLTest.js
+++ b/addons/Text_Coloring/test/PrintHTMLTest.js
@@ -68,8 +68,8 @@ TestCase("[Text_Coloring] get printable HTML", {
 
     'test given model when getColors was called should return defined colors in grayscale': function () {
         var mockColors = [
-            {'name':'red', 'value':'#787878'},
-            {'name':'blue', 'value':'#8f8f8f'}
+            {'id': 'red', 'value':'#787878'},
+            {'id': 'blue', 'value':'#8f8f8f'}
         ];
         var colors = this.presenter.getColors(this.model);
 

--- a/addons/Text_Coloring/test/StateTests.js
+++ b/addons/Text_Coloring/test/StateTests.js
@@ -44,12 +44,14 @@ TestCase("[Text_Coloring] getState/setState", {
 
         this.stubs = {
             colorAllMarkedTokens: sinon.stub(this.presenter, 'colorAllMarkedTokens'),
+            show: sinon.stub(this.presenter, 'show'),
             hide: sinon.stub(this.presenter, 'hide')
         };
     },
 
     tearDown: function () {
         this.presenter.colorAllMarkedTokens.restore();
+        this.presenter.show.restore();
         this.presenter.hide.restore();
     },
 
@@ -105,10 +107,10 @@ TestCase("[Text_Coloring] getState/setState", {
         assertFalse(this.presenter.configuration.isVisible);
     },
 
-    'test set state should not hide if addon is visible': function () {
+    'test set state should show if addon is visible': function () {
         this.presenter.setState(this.stringifiedStateVisible);
 
-        assertFalse(this.stubs.hide.called);
+        assertTrue(this.stubs.show.calledOnce);
         assertTrue(this.presenter.configuration.isVisible);
     }
 });

--- a/addons/Text_Coloring/test/VisibilityTests.js
+++ b/addons/Text_Coloring/test/VisibilityTests.js
@@ -18,19 +18,22 @@ TestCase('[Text_Coloring] Visibility tests', {
             setViewStub: sinon.stub(),
             colorTokensInPreviewStub: sinon.stub(),
             connectHandlersStub: sinon.stub(),
-            setColorStub: sinon.stub()
+            setColorStub: sinon.stub(),
+            buildKeyboardControllerStub: sinon.stub(),
+            setSpeechTextsStub: sinon.stub()
         };
 
         this.presenter.validateModel = this.stubs.validateModelStub;
         this.presenter.hide = this.stubs.hideStub;
         this.presenter.upgradeModel = this.stubs.upgradeModelStub;
+        this.presenter.upgradeModel.returns({});
         this.presenter.setFilteredTokensData = this.stubs.setFilteredTokensDataStub;
         this.presenter.setView = this.stubs.setViewStub;
         this.presenter.colorTokensInPreview = this.stubs.colorTokensInPreviewStub;
         this.presenter.connectHandlers = this.stubs.connectHandlersStub;
         this.presenter.setColor = this.stubs.setColorStub;
-
-
+        this.presenter.buildKeyboardController = this.stubs.buildKeyboardControllerStub;
+        this.presenter.setSpeechTexts = this.stubs.setSpeechTextsStub;
 
 		this.view = document.createElement('div');
     },
@@ -45,6 +48,7 @@ TestCase('[Text_Coloring] Visibility tests', {
 
     'test when in preview mode and addon is not visible, hide should not be called': function () {
         this.stubs.validateModelStub.returns(getValidModel(false));
+
         this.presenter.createPreview(this.view, {});
 
         assertFalse(this.stubs.hideStub.called);
@@ -52,6 +56,7 @@ TestCase('[Text_Coloring] Visibility tests', {
 
     'test when not in preview mode and addon is visible, setVisibility should be called with true': function () {
         this.stubs.validateModelStub.returns(getValidModel(true));
+
         this.presenter.run(this.view, {});
 
         assertFalse(this.stubs.hideStub.called);

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2023-04-18 Fixed print of text coloring when color ID is not equal to color description
 2023-04-04 Adding gap grouping in the Text module
 2023-04-04 Fixed displaying answers in the hidden Multiplegap
 2023-04-03 Fixed loading subtitles preview in editor


### PR DESCRIPTION
[Ticket](https://learneticsa.assembla.com/spaces/lorepo/tickets/8717--sejer--b%C5%82%C4%85d-w-drukowaniu-text-coloring/details)
[Wersja testowa](https://test-8717-dot-mauthor-dev.ew.r.appspot.com)
[Lekcja testowa](https://test-8717-dot-mauthor-dev.ew.r.appspot.com/embed/5394239116541952)

**Uwaga**. Wersja na produkcji i mauthor-dev z nieznanego mi powodu wykonuje się getPrintableHTML przy wejściu na na widok present i embed. Moje wersje nie mają tego problemu. Z tego powodu nawet przy braku tych zmian nie wyświetlał mi się błąd dopóki nie wykonałem komend na generowanie drukowalnych wersji.

**Note**. Zmiany te poprawiają wcześniej nie działające testy.