### PR TITLE
Expand support for alternative texts in Quiz addon, re #8702

### DIFF
--- a/addons/Quiz/jsTestDriver.conf
+++ b/addons/Quiz/jsTestDriver.conf
@@ -4,5 +4,6 @@ load:
     - ../tools/jquery-1.7.1.js
     - ../tools/sinon-2.4.1.js
     - ../../src/main/java/com/lorepo/icplayer/public/libs/commons.js
+    - ../../src/main/java/com/lorepo/icplayer/public/libs/purify.js
     - src/*.js
     - test/*.js

--- a/addons/Quiz/src/presenter.js
+++ b/addons/Quiz/src/presenter.js
@@ -198,12 +198,12 @@ function AddonQuiz_create() {
             visibility: ModelValidationUtils.validateBoolean(model['Is Visible']),
             questions: validateQuestions(model['Questions'], helpButtons, model["HelpButtonsMode"]),
             helpButtons: helpButtons,
-            nextLabel: window.xssUtils.sanitize(model['NextLabel'] || ''),
-            gameLostMessage: window.xssUtils.sanitize(model['GameLostMessage']),
-            gameWonMessage: window.xssUtils.sanitize(model['GameWonMessage']),
-            gameSummaryMessage: window.xssUtils.sanitize(model['GameSummaryMessage']),
-            correctGameMessage: window.xssUtils.sanitize(model['CorrectGameMessage']),
-            wrongGameMessage: window.xssUtils.sanitize(model['WrongGameMessage']),
+            nextLabel: model['NextLabel'] || '',
+            gameLostMessage: model['GameLostMessage'],
+            gameWonMessage: model['GameWonMessage'],
+            gameSummaryMessage: model['GameSummaryMessage'],
+            correctGameMessage: model['CorrectGameMessage'],
+            wrongGameMessage: model['WrongGameMessage'],
             centerVertically: ModelValidationUtils.validateBoolean(model['Center vertically']),
             isActivity: ModelValidationUtils.validateBoolean(model['isActivity']),
             isVisible: ModelValidationUtils.validateBoolean(model['Is Visible']),
@@ -241,14 +241,31 @@ function AddonQuiz_create() {
         var wrapper = $('<div class="game-won-message-wrapper"></div>');
         var message = $(`<div class="${CSS_CLASSES.GAME_WON_MESSAGE}"></div>`);
         if(presenter.config.showSummary) {
-            message.html(
+            message.html(window.xssUtils.sanitize(
                 parseAltText(presenter.config.gameWonMessage) +
                 '<div>' + parseAltText(presenter.config.gameSummaryMessage) +
                 '<div>' + parseAltText(presenter.config.correctGameMessage) + ': ' + getScore() +
                 '</div><div>' + parseAltText(presenter.config.wrongGameMessage) + ': ' + (presenter.config.questions.length - getScore()) +
-                '</div>' + '</div>');
+                '</div>' + '</div>'));
         } else {
-            message.html(parseAltText(presenter.config.gameWonMessage));
+            message.html(window.xssUtils.sanitize(parseAltText(presenter.config.gameWonMessage)));
+        }
+        wrapper.append(message);
+        showInHintArea(wrapper);
+    };
+
+    function gameLostMessage() {
+        var wrapper = $('<div class="game-lost-message-wrapper"></div>');
+        var message = $(`<div class="${CSS_CLASSES.GAME_LOST_MESSAGE}"></div>`);
+        if(presenter.config.showSummary) {
+            message.html(window.xssUtils.sanitize(
+                parseAltText(presenter.config.gameLostMessage) +
+                '<div>' + parseAltText(presenter.config.gameSummaryMessage) +
+                '<div>' + parseAltText(presenter.config.correctGameMessage) + ': ' + getScore() +
+                '</div><div>' + parseAltText(presenter.config.wrongGameMessage) + ': ' + (presenter.config.questions.length - getScore()) +
+                '</div>' + '</div>'));
+        }else{
+            message.html(window.xssUtils.sanitize(parseAltText(presenter.config.gameLostMessage)));
         }
         wrapper.append(message);
         showInHintArea(wrapper);
@@ -257,23 +274,6 @@ function AddonQuiz_create() {
     function parseAltText(text) {
         return presenter.preview ? window.TTSUtils.parsePreviewAltText(text) : presenter.textParser.parse(text);
     }
-
-    function gameLostMessage() {
-        var wrapper = $('<div class="game-lost-message-wrapper"></div>');
-        var message = $(`<div class="${CSS_CLASSES.GAME_LOST_MESSAGE}"></div>`);
-        if(presenter.config.showSummary) {
-            message.html(
-                parseAltText(presenter.config.gameLostMessage) +
-                '<div>' + parseAltText(presenter.config.gameSummaryMessage) +
-                '<div>' + parseAltText(presenter.config.correctGameMessage) + ': ' + getScore() +
-                '</div><div>' + parseAltText(presenter.config.wrongGameMessage) + ': ' + (presenter.config.questions.length - getScore()) +
-                '</div>' + '</div>');
-        }else{
-            message.html(parseAltText(presenter.config.gameLostMessage));
-        }
-        wrapper.append(message);
-        showInHintArea(wrapper);
-    };
 
     function getSelectItemAction(answer, $this) {
         var isCorrect = answer == getCurrentQuestion().CorrectAnswer;
@@ -426,7 +426,7 @@ function AddonQuiz_create() {
 
     function showHint() {
         var $hint = $(`<div class="${CSS_CLASSES.QUESTION_HINT}"></div>`);
-        $hint.html(parseAltText(getCurrentQuestion().Hint));
+        $hint.html(window.xssUtils.sanitize(parseAltText(getCurrentQuestion().Hint)));
         showInHintArea($hint);
         presenter.$view.find('.hint-button').addClass('used');
     }
@@ -476,7 +476,7 @@ function AddonQuiz_create() {
         var $title = $(`<div class="${CSS_CLASSES.QUESTION_TITLE}"></div>`);
         var $tips = $('<div class="question-tips"></div>');
         var $nextButton = $(`<div class="${CSS_CLASSES.NEXT_QUESTION_BUTTON}"></div>`);
-        $nextButton.html(parseAltText(presenter.config.nextLabel));
+        $nextButton.html(window.xssUtils.sanitize(parseAltText(presenter.config.nextLabel)));
         $nextButton.clickAction = nextButtonAction;
 
         cleanWorkspace();

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2023-04-26 Expanded support for alternative texts in Quiz addon
 2023-04-04 Adding gap grouping in the Text module
 2023-04-04 Fixed displaying answers in the hidden Multiplegap
 2023-04-03 Fixed loading subtitles preview in editor


### PR DESCRIPTION
[Ticket](https://learneticsa.assembla.com/spaces/lorepo/tickets/8702-quiz---dodanie-wsparcia-dla-alt-text/details)
[Wersja testowa](https://test-8702-dot-mauthor-dev.ew.r.appspot.com)
[Lekcja testowa](https://test-8702-dot-mauthor-dev.ew.r.appspot.com/present/6199451397914624)

Wynik tego zadania wprowadzałby lukę wpisania skryptów do tych property do którego można było coś wpisać.
Z tego powodu dodano zabezpieczenie na taką ewentualność co należy także sprawdzić na wersji testowej. 
Strona numer 2 z powyższej lekcji sprawdza zabezpieczenia. Należy także sprawdzić edytor.
