### PR TITLE
Fix problem with incorrect conversion of & to &amp; in links in text module, re #8719

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2023-04-27 Fixed problem with incorrect conversion of & to &amp; in links in text module
 2023-04-04 Adding gap grouping in the Text module
 2023-04-04 Fixed displaying answers in the hidden Multiplegap
 2023-04-03 Fixed loading subtitles preview in editor

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
@@ -24,6 +24,7 @@ import com.lorepo.icplayer.client.module.text.TextPresenter.NavigationTextElemen
 import com.lorepo.icplayer.client.page.PageController;
 import com.lorepo.icplayer.client.utils.MathJax;
 import com.lorepo.icplayer.client.utils.MathJaxElement;
+import com.lorepo.icf.utils.JavaScriptUtils;
 
 import java.util.*;
 
@@ -237,7 +238,8 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 						event.stopPropagation();
 						event.preventDefault();
 						if (listener != null) {
-							listener.onLinkClicked(info.getType(), info.getHref(), info.getTarget());
+							String validLink = StringUtils.unescapeXML(info.getHref());
+							listener.onLinkClicked(info.getType(), validLink, info.getTarget());
 						}
 						event.preventDefault();
 					}
@@ -366,6 +368,7 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 
 	@Override
 	public void addListener(ITextViewListener l) {
+		JavaScriptUtils.log("addListener");
 		listener = l;
 	}
 

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
@@ -24,7 +24,6 @@ import com.lorepo.icplayer.client.module.text.TextPresenter.NavigationTextElemen
 import com.lorepo.icplayer.client.page.PageController;
 import com.lorepo.icplayer.client.utils.MathJax;
 import com.lorepo.icplayer.client.utils.MathJaxElement;
-import com.lorepo.icf.utils.JavaScriptUtils;
 
 import java.util.*;
 
@@ -368,7 +367,6 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 
 	@Override
 	public void addListener(ITextViewListener l) {
-		JavaScriptUtils.log("addListener");
 		listener = l;
 	}
 


### PR DESCRIPTION
[Ticket](https://learneticsa.assembla.com/spaces/lorepo/tickets/8719--support--text-(grup-enciclopedia)-i-c-amp-e-publishing--znak--amp--w-linku-w/details)
[Wersja testowa](https://test-8719-dot-mauthor-dev.ew.r.appspot.com)
[Lekcja testowa](https://test-8719-dot-mauthor-dev.ew.r.appspot.com/present/6445112521392128#5)

**Dla programisty - Wyjaśnienie problemu**
W addonach które korzystają z TextParser np. moduł Text i Choice, linki są zapisane w niepoprawnej formie zawierającej dalej '& amp;' w linkach zamiast &. Jeżeli nie dodamy własnej obsługi kliknięcia w link (nie użyjemy preventDefault) to nawet z takim błędem poprawnie będzie się otwierać link (przypadek choice). Gdy stworzy się własnego handlera, który to ma preventDefault to należy ten link najpierw oczyścić z XML zanim go się otworzy (przypadek text).