### PR TITLE
Change text module not to reset state for Gradual Hide Answers to state before Gradual Show Answers, re #8789

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2023-05-08 Changed text module not to reset state for Gradual Hide Answers to state before Gradual Show Answers
 2023-04-04 Adding gap grouping in the Text module
 2023-04-04 Fixed displaying answers in the hidden Multiplegap
 2023-04-03 Fixed loading subtitles preview in editor


### PR DESCRIPTION
[Ticket](https://app.assembla.com/spaces/lorepo/tickets/8789-(2)-chowanie-modu%C5%82%C3%B3w-+-gha-(ticket-klienta)/details)
[Wersja testowa](https://test-8789-dot-mauthor-dev.ew.r.appspot.com)
[Lekcja testowa](https://test-8789-dot-mauthor-dev.ew.r.appspot.com/present/5203215077343232)
[Lekcja testowa 2](https://test-8789-dot-mauthor-dev.ew.r.appspot.com/present/5325910381166592)

Proszę o dokładne testy w różnych sytuacjach dla GHA i GSA. 
W module tekst GSA jest wykonane w taki sposób, że najpierw czyszczy zbędny stan (np. check errors), zapisuje stan a następnie go ustawia przy wykonaniu GHA. Czyli komendy wykonane pomiędzy GSA i GHA w większości nie miały wpływu na stan po GHA.

Modyfikacja tego ticketu polega na tym, że jeżeli zostanie wykonana komenda w module tekst, gdy jest aktywny GSA to wykonywana jest funkcjonalność GHA, co zapobieganie resetowi stanu ustawionego przed faktycznym wykonaniem GHA. W ten sposób już działa Show answers i Hide answers w module text.