### PR TITLE
Fix Advance Connector addon losing context of Show Answers and Hide Answers event, re #8791

### DIFF
--- a/addons/Advanced_Connector/src/presenter.js
+++ b/addons/Advanced_Connector/src/presenter.js
@@ -15,7 +15,9 @@ function AddonAdvanced_Connector_create() {
         'Done',
         'AllAttempted',
         'NotAllAttempted',
-        'LimitedCheck'
+        'LimitedCheck',
+        'GradualShowAnswers',
+        'GradualHideAnswers',
     ];
 
     presenter.setPlayerController = function (controller) {
@@ -27,11 +29,12 @@ function AddonAdvanced_Connector_create() {
             return;
         }
         var i, length;
-        event = presenter.fillEventData(eventData, eventName);
+        let filledEventData = presenter.fillEventData(eventData, eventName);
 
         try {
-            var filteredEvents = presenter.filterEvents(presenter.events, event);
+            var filteredEvents = presenter.filterEvents(presenter.events, filledEventData);
             for (i = 0, length = filteredEvents.length; i < length; i++) {
+                event = filledEventData;
                 eval(filteredEvents[i].Code);
             }
         } catch (error) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2023-05-19 Fixed Advance Connector addon losing context of Show Answers and Hide Answers event
 2023-05-18 Fixed reading stoppage (TTS)
 2023-05-16 Changed Text and Choice module do not reset visibility for Gradual Hide Answers
 2023-05-16 Fixed issue with show and hide in Text when in showAnswers mode


### PR DESCRIPTION
[Ticket](https://app.assembla.com/spaces/lorepo/tickets/8791-(4)-eventy---logi-w-konsoli/details)
[Wersja Testowa](https://test-8791-dot-mauthor-dev.ew.r.appspot.com)
[Lekcja Testowa](https://test-8791-dot-mauthor-dev.ew.r.appspot.com/present/5141043748012032)

Dla programisty - wytłumaczenie błędu:
(1) Błąd "funkcje SA/HA wysyłają eventy, ale w logu pojawia się undefined"
onEventReceived w addonie AC działa rekurencyjnie oraz ta metoda wykonuje listę kodów. Wykonanie komendy `presenter.playerController.getCommands().showAnswers()` lub odpowiednika hideAnswers wywoływało kolejny event, który to był ponownie łapany przez AC i wykonywany przez onEventReceived, zanim poprzedni onEventReceived się wykonał.

undefined w konsoli wynikało z ostatniej linijki tej metody, gdzie "undefined" było przypisywane jako "event". Jeżeli wystąpiło zagnieżdżenie to nadpisywało w ten sposób zmienną "event", która ta była później używana w iteracjach wcześniejszych (wyższego poziomu).

(2) Błąd "funkcje GSA/GHA chyba wysyłają eventy (bo zwykłe teksty na nie reagują), ale ich nie widać w logach - może się mylę, ale to wygląda, jakby stare moduły java (ic) dostawały eventy a nowsze addony javascript nie dostawały tych eventów"
Eventy dla GSA i GHA, nigdy nie były nasłuchiwane w kodzie użytkownika w AC. Dodałem nasłuchiwanie