### PR TITLE
Fix dropdownClicked event received behaviour in Audio, TextAudio, Video and MultiAudio addon when paused, re #8779

### DIFF
--- a/addons/Audio/src/presenter.js
+++ b/addons/Audio/src/presenter.js
@@ -31,10 +31,18 @@ function AddonAudio_create(){
     presenter.mouseData = {};
 
     presenter.onEventReceived = function AddonAudio_onEventReceived (eventName, eventData) {
-        if(eventData.value == 'dropdownClicked' && !presenter.audio.playing) {
+        if (eventData.value == 'dropdownClicked' && !presenter.audio.playing && !isTemporarilyPaused()) {
             presenter.audio.load();
         }
     };
+
+    function isTemporarilyPaused() {
+        return (presenter.audio.paused
+            && presenter.audio.readyState > 2
+            && presenter.audio.currentTime > 0
+            && !presenter.audio.ended
+        );
+    }
 
     presenter.setPlayerController = function AddonAudio_setPlayerController (controller) {
         presenter.playerController = controller;

--- a/addons/MultiAudio/src/presenter.js
+++ b/addons/MultiAudio/src/presenter.js
@@ -27,7 +27,7 @@ function AddonMultiAudio_create(){
     
     presenter.onEventReceived = function(eventName, eventData) {
         if (eventName == "ValueChanged") {
-            if (eventData.value == 'dropdownClicked') {
+            if (eventData.value == 'dropdownClicked' && !presenter.audio.playing && !isTemporarilyPaused()) {
                 this.audio.load();
             }
         }else if (eventName == "ItemConsumed") {
@@ -62,6 +62,14 @@ function AddonMultiAudio_create(){
             this.applySelectedClass(itemID);
         }
     };
+
+    function isTemporarilyPaused() {
+        return (presenter.audio.paused
+            && presenter.audio.readyState > 2
+            && presenter.audio.currentTime > 0
+            && !presenter.audio.ended
+        );
+    }
 
     function getItemIdFromEvent(eventDataItem) {
         var addonAndItemIds = eventDataItem.split('-');
@@ -236,6 +244,12 @@ function AddonMultiAudio_create(){
                 presenter.createDraggableItems(model['Files']);
                 break;
         }
+
+        Object.defineProperty(presenter.audio, 'playing', {
+            get: function () {
+                return !!(this.currentTime > 0 && !this.paused && !this.ended && this.readyState > 2);
+            }
+        });
     };
 
     presenter.createDraggableItems = function(filesModel) {

--- a/addons/TextAudio/src/presenter.js
+++ b/addons/TextAudio/src/presenter.js
@@ -115,10 +115,18 @@ function AddonTextAudio_create() {
     };
 
     presenter.onEventReceived = function AddonTextAudio_onEventReceived (eventName, eventData) {
-        if(eventData.value == 'dropdownClicked' && !presenter.audio.playing) {
+        if(eventData.value == 'dropdownClicked' && !presenter.audio.playing && !isTemporarilyPaused()) {
             presenter.audio.load();
         }
     };
+
+    function isTemporarilyPaused() {
+        return (presenter.audio.paused
+            && presenter.audio.readyState > 2
+            && presenter.audio.currentTime > 0
+            && !presenter.audio.ended
+        );
+    }
 
     presenter.showLoadingArea = function AddonTextAudio_showLoadingArea (clickAction) {
         if (clickAction === 'play_vocabulary_interval' && presenter.buzzAudio.length === 0 && !MobileUtils.isMobileUserAgent(navigator.userAgent)) {

--- a/addons/video/src/presenter.js
+++ b/addons/video/src/presenter.js
@@ -312,11 +312,19 @@ function Addonvideo_create() {
 
     presenter.onEventReceived = function (eventName, eventData) {
         presenter.pageLoadedDeferred.resolve();
-        if (eventData.value === 'dropdownClicked' && !presenter.videoObject.playing) {
+        if (eventData.value === 'dropdownClicked' && !presenter.videoObject.playing && !isTemporarilyPaused()) {
             presenter.metadadaLoaded = false;
             presenter.videoObject.load();
         }
     };
+
+    function isTemporarilyPaused() {
+        return (presenter.videoObject.paused
+            && presenter.videoObject.readyState > 2
+            && presenter.videoObject.currentTime > 0
+            && !presenter.videoObject.ended
+        );
+    }
 
     presenter.createEndedEventData = function (currentVideo) {
         return {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2023-05-25 Fixed dropdownClicked event received behaviour in Audio, TextAudio, Video and MultiAudio addon when paused
 2023-05-18 Fixed reading stoppage (TTS)
 2023-05-16 Changed Text and Choice module do not reset visibility for Gradual Hide Answers
 2023-05-16 Fixed issue with show and hide in Text when in showAnswers mode


### PR DESCRIPTION
[Ticket](https://learneticsa.assembla.com/spaces/lorepo/tickets/8779--audio-+-text--pierwsze-klikni%C4%99cie-na-dropdown-resetuje-licznik-sekund/details)
[Wersja testowa](https://test-8779-dot-mauthor-dev.ew.r.appspot.com)
[Lekcja testowa](https://test-8779-dot-mauthor-dev.ew.r.appspot.com/present/6546241485799424)
[Kopia lekcji klienta](https://test-8779-dot-mauthor-dev.ew.r.appspot.com/present/5254372869013504#2)