### PR TITLE
Fix dragging out responses from draggable gap after changing page in Table addon, re #8785

### DIFF
--- a/addons/Table/src/presenter.js
+++ b/addons/Table/src/presenter.js
@@ -1392,7 +1392,7 @@ function AddonTable_create() {
         var value = configuration.value;
         var source = configuration.source;
         var isEnabled = configuration.isEnabled;
-        var droppedElement = configuration.droppable;
+        var droppedElement = configuration.droppedElement;
         this.isAttempted = configuration.isAttempted === undefined ? false : configuration.isAttempted;
 
         if (presenter.configuration.gapType === "draggable") {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2023-05-26 Fixed dragging out responses from draggable gap after changing page in Table addon
 2023-05-26 Fixed Advance Connector addon losing context of Show Answers and Hide Answers event
 2023-05-26 Fixed reading dots in text list
 2023-05-26 Fixed dropdownClicked event received behaviour in Audio, TextAudio, Video and MultiAudio addon when paused


### PR DESCRIPTION
[Ticket](https://learneticsa.assembla.com/spaces/lorepo/tickets/8785--aga--table---nie-mo%C5%BCna-usun%C4%85%C4%87-odpowiedzi-z-gapy-draggowalnej-prz/details)
[Wersja testowa](https://test-8785-dot-mauthor-dev.ew.r.appspot.com/)
[Lekcja testowa](https://test-8785-dot-mauthor-dev.ew.r.appspot.com/present/5094932610023424)

Naprawiono niedziałający poprawnie setState od 2019 roku