### PR TITLE
Add alphabetical sorting of CSS classes, re #8814

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2023-06-19 Added alphabetical sorting of CSS classes
 2023-06-07 Added conversion to mp3 in media recorder after recording is complete
 2023-06-07 Fixed Show Answers with mistake counter activated in Points and Lines
 2023-06-07 Fixed keyboard navigation not working correctly when there's a mix of draggable and editable gaps in Text

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/bl/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/bl/dictionary.js
@@ -245,7 +245,7 @@ var ice_dictionary_bl = {
 	"css_class" : "CSS клас:",
 	"inline_css" : "Инлайн CSS:",
 	"styles_sort_label" : "Sort",
-	"can_not_save_styles_sort_selected": "Non-logged user can not save their CSS class sort preference",
+	"can_not_save_styles_sort_selected": "Can't save CSS class sort preference",
 	"update_style" : "Обновяване на стила",
 	"cant_load_document" : "Документът не може да се зареди: ",
 	"cant_add_page" : "Страницата не може да бъде добавена: ",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/bl/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/bl/dictionary.js
@@ -244,6 +244,8 @@ var ice_dictionary_bl = {
 	"styles" : "Стилове",
 	"css_class" : "CSS клас:",
 	"inline_css" : "Инлайн CSS:",
+	"styles_sort_label" : "Sort",
+	"can_not_save_styles_sort_selected": "Non-logged user can not save their CSS class sort preference",
 	"update_style" : "Обновяване на стила",
 	"cant_load_document" : "Документът не може да се зареди: ",
 	"cant_add_page" : "Страницата не може да бъде добавена: ",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/com/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/com/dictionary.js
@@ -245,7 +245,7 @@ var ice_dictionary_en = {
 	"css_class" : "CSS class:",
 	"inline_css" : "Inline CSS:",
 	"styles_sort_label" : "Sort",
-	"can_not_save_styles_sort_selected": "Non-logged user can not save their CSS class sort preference",
+	"can_not_save_styles_sort_selected": "Can't save CSS class sort preference",
 	"update_style" : "Update style",
 	"cant_load_document" : "Can't load document: ",
 	"cant_add_page" : "Can't add page: ",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/com/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/com/dictionary.js
@@ -244,6 +244,8 @@ var ice_dictionary_en = {
 	"styles" : "Styles",
 	"css_class" : "CSS class:",
 	"inline_css" : "Inline CSS:",
+	"styles_sort_label" : "Sort",
+	"can_not_save_styles_sort_selected": "Non-logged user can not save their CSS class sort preference",
 	"update_style" : "Update style",
 	"cant_load_document" : "Can't load document: ",
 	"cant_add_page" : "Can't add page: ",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/fr/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/fr/dictionary.js
@@ -244,6 +244,8 @@ var ice_dictionary_fr = {
     "styles" : "Styles",
     "css_class" : "Classes CSS :",
     "inline_css" : "CSS du module :",
+    "styles_sort_label" : "Sort",
+	"can_not_save_styles_sort_selected": "Non-logged user can not save their CSS class sort preference",
     "update_style" : "Mettre à jour le style",
     "cant_load_document" : "Impossible de charger le document :",
     "cant_add_page" : "Impossible d'ajouter la page :",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/fr/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/fr/dictionary.js
@@ -245,7 +245,7 @@ var ice_dictionary_fr = {
     "css_class" : "Classes CSS :",
     "inline_css" : "CSS du module :",
     "styles_sort_label" : "Sort",
-	"can_not_save_styles_sort_selected": "Non-logged user can not save their CSS class sort preference",
+	"can_not_save_styles_sort_selected": "Can't save CSS class sort preference",
     "update_style" : "Mettre à jour le style",
     "cant_load_document" : "Impossible de charger le document :",
     "cant_add_page" : "Impossible d'ajouter la page :",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/mx/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/mx/dictionary.js
@@ -245,7 +245,7 @@ var ice_dictionary_mx = {
 	"css_class": "Clase CSS:",
 	"inline_css": "CSS embebido:",
 	"styles_sort_label" : "Sort",
-	"can_not_save_styles_sort_selected": "Non-logged user can not save their CSS class sort preference",
+	"can_not_save_styles_sort_selected": "Can't save CSS class sort preference",
 	"update_style": "Actualizar estilo",
 	"cant_load_document": "No se puede cargar el documento:",
 	"cant_add_page": "No se puede añadir la página:",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/mx/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/mx/dictionary.js
@@ -244,6 +244,8 @@ var ice_dictionary_mx = {
 	"styles": "Estilos",
 	"css_class": "Clase CSS:",
 	"inline_css": "CSS embebido:",
+	"styles_sort_label" : "Sort",
+	"can_not_save_styles_sort_selected": "Non-logged user can not save their CSS class sort preference",
 	"update_style": "Actualizar estilo",
 	"cant_load_document": "No se puede cargar el documento:",
 	"cant_add_page": "No se puede añadir la página:",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/pl/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/pl/dictionary.js
@@ -244,6 +244,8 @@ var ice_dictionary_pl = {
 	"styles" : "Style",
 	"css_class" : "Klasa CSS:",
 	"inline_css" : "CSS wplatany:",
+	"styles_sort_label" : "Sort",
+	"can_not_save_styles_sort_selected": "Non-logged user can not save their CSS class sort preference",
 	"update_style" : "Aktualizuj styl",
 	"cant_load_document" : "Nie można wczytać dokumentu: ",
 	"cant_add_page" : "Nie można dodać strony: ",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/pl/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/pl/dictionary.js
@@ -245,7 +245,7 @@ var ice_dictionary_pl = {
 	"css_class" : "Klasa CSS:",
 	"inline_css" : "CSS wplatany:",
 	"styles_sort_label" : "Sort",
-	"can_not_save_styles_sort_selected": "Non-logged user can not save their CSS class sort preference",
+	"can_not_save_styles_sort_selected": "Can't save CSS class sort preference",
 	"update_style" : "Aktualizuj styl",
 	"cant_load_document" : "Nie można wczytać dokumentu: ",
 	"cant_add_page" : "Nie można dodać strony: ",


### PR DESCRIPTION
[Ticket](https://app.assembla.com/spaces/lorepo/tickets/8814-2--sortowanie-alfabetyczne-klas---dzia%C5%82a-od-razu--bez-%C5%BCadnej-zach/details)
[PR iceditor](https://github.com/LearneticSA/iceditor/pull/39)
[PR mauthor](https://github.com/LearneticSA/mAuthor/pull/136)
[Wersja testowa](https://test-8793-dot-mauthor-dev.ew.r.appspot.com/)
[Lekcja testowa (do skopiowania)](https://test-8814-dot-mauthor-dev.ew.r.appspot.com/present/6235019347492864)