### PR TITLE
Fix Basic Math Gaps addon not working correctly when Show Answers increments mistake counter, re #8830

### DIFF
--- a/addons/Basic_Math_Gaps/src/presenter.js
+++ b/addons/Basic_Math_Gaps/src/presenter.js
@@ -801,6 +801,11 @@ function AddonBasic_Math_Gaps_create(){
     };
 
     presenter.getState = function(){
+        let wasShowAnswersActive = false;
+        if (presenter.configuration.isShowAnswersActive) {
+            wasShowAnswersActive = true;
+            presenter.hideAnswers();
+        }
         var state = {
             'values' : presenter.gapsContainer.getValues(),
             'sources': presenter.gapsContainer.getSources(),
@@ -809,6 +814,7 @@ function AddonBasic_Math_Gaps_create(){
             'droppedElements' : presenter.gapsContainer.getDroppedElements()
         };
 
+        wasShowAnswersActive ? presenter.showAnswers() : "";
         return JSON.stringify(state);
     };
 

--- a/addons/Basic_Math_Gaps/src/presenter.js
+++ b/addons/Basic_Math_Gaps/src/presenter.js
@@ -595,18 +595,22 @@ function AddonBasic_Math_Gaps_create(){
     };
 
     presenter.getErrorCount = function(){
+        let wasShowAnswersActive = false;
         if (presenter.configuration.isShowAnswersActive) {
+            wasShowAnswersActive = true;
             presenter.hideAnswers();
         }
 
+        let errorCount = _getErrorCount();
+        wasShowAnswersActive ? presenter.showAnswers() : "";
+        return errorCount;
+    };
+
+    function _getErrorCount () {
         if (presenter.cantCheck()) {
             return 0;
         }
 
-        return _getErrorCount();
-    };
-
-    function _getErrorCount () {
         var validated = presenter.validateScore();
 
         if (presenter.configuration.isEquation) {
@@ -753,10 +757,18 @@ function AddonBasic_Math_Gaps_create(){
     };
 
     presenter.getScore = function () {
+        let wasShowAnswersActive = false;
         if (presenter.configuration.isShowAnswersActive) {
+            wasShowAnswersActive = true;
             presenter.hideAnswers();
         }
 
+        let score = _getScore();
+        wasShowAnswersActive ? presenter.showAnswers() : "";
+        return score;
+    };
+
+    function _getScore() {
         if (presenter.cantCheck()) {
             return 0;
         }
@@ -776,7 +788,7 @@ function AddonBasic_Math_Gaps_create(){
         } else {
             return validated.validGapsCount;
         }
-    };
+    }
 
     presenter.cantCheck = function () {
         if (presenter.configuration.isNotActivity

--- a/addons/Basic_Math_Gaps/src/presenter.js
+++ b/addons/Basic_Math_Gaps/src/presenter.js
@@ -595,14 +595,13 @@ function AddonBasic_Math_Gaps_create(){
     };
 
     presenter.getErrorCount = function(){
-        let wasShowAnswersActive = false;
+        const wasShowAnswersActive = presenter.configuration.isShowAnswersActive;
         if (presenter.configuration.isShowAnswersActive) {
-            wasShowAnswersActive = true;
             presenter.hideAnswers();
         }
 
-        let errorCount = _getErrorCount();
-        wasShowAnswersActive ? presenter.showAnswers() : "";
+        const errorCount = _getErrorCount();
+        wasShowAnswersActive && presenter.showAnswers();
         return errorCount;
     };
 
@@ -757,14 +756,13 @@ function AddonBasic_Math_Gaps_create(){
     };
 
     presenter.getScore = function () {
-        let wasShowAnswersActive = false;
+        const wasShowAnswersActive = presenter.configuration.isShowAnswersActive;
         if (presenter.configuration.isShowAnswersActive) {
-            wasShowAnswersActive = true;
             presenter.hideAnswers();
         }
 
-        let score = _getScore();
-        wasShowAnswersActive ? presenter.showAnswers() : "";
+        const score = _getScore();
+        wasShowAnswersActive && presenter.showAnswers();
         return score;
     };
 
@@ -801,9 +799,8 @@ function AddonBasic_Math_Gaps_create(){
     };
 
     presenter.getState = function(){
-        let wasShowAnswersActive = false;
+        const wasShowAnswersActive = presenter.configuration.isShowAnswersActive;
         if (presenter.configuration.isShowAnswersActive) {
-            wasShowAnswersActive = true;
             presenter.hideAnswers();
         }
         var state = {
@@ -814,7 +811,7 @@ function AddonBasic_Math_Gaps_create(){
             'droppedElements' : presenter.gapsContainer.getDroppedElements()
         };
 
-        wasShowAnswersActive ? presenter.showAnswers() : "";
+        wasShowAnswersActive && presenter.showAnswers();
         return JSON.stringify(state);
     };
 

--- a/addons/Basic_Math_Gaps/test/ErrorsCountTests.js
+++ b/addons/Basic_Math_Gaps/test/ErrorsCountTests.js
@@ -18,7 +18,8 @@ TestCase("[Basic Math Gaps] Get Error Count", {
 
             isEquationCorrect: sinon.stub(this.presenter, 'isEquationCorrect'),
 
-            validateScore: sinon.stub(this.presenter, 'validateScore')
+            validateScore: sinon.stub(this.presenter, 'validateScore'),
+            showAnswers: sinon.stub(this.presenter, 'showAnswers')
         };
 
         this.stubs.validateScore.returns({
@@ -30,6 +31,7 @@ TestCase("[Basic Math Gaps] Get Error Count", {
 
     tearDown: function () {
         this.presenter.hideAnswers.restore();
+        this.presenter.showAnswers.restore();
         this.presenter.isEquationCorrect.restore();
         this.presenter.validateScore.restore();
 
@@ -39,18 +41,20 @@ TestCase("[Basic Math Gaps] Get Error Count", {
         this.presenter.GapsContainerObject.prototype.getNonEmptyGapsNumber.restore();
     },
 
-    'test should hide answers if show answers is active': function () {
+    'test should hide answers if show answers is active and restore after': function () {
         this.presenter.configuration.isShowAnswersActive = true;
 
         this.presenter.getErrorCount();
 
         assertTrue(this.stubs.hideAnswers.calledOnce);
+        assertTrue(this.stubs.showAnswers.calledOnce);
     },
 
     'test shouldnt hide answers if show answers isnt active ': function () {
         this.presenter.getErrorCount();
 
         assertFalse(this.stubs.hideAnswers.called);
+        assertFalse(this.stubs.showAnswers.called);
     },
 
     'test should return zero errors if is not activity': function () {

--- a/addons/Basic_Math_Gaps/test/ScoresTests.js
+++ b/addons/Basic_Math_Gaps/test/ScoresTests.js
@@ -18,7 +18,9 @@ TestCase("[Basic Math Gaps] Score Tests", {
             getMaxScore: sinon.stub(this.presenter.GapsContainerObject.prototype, 'getMaxScore'),
             areAllGapsEmpty: sinon.stub(this.presenter.GapsContainerObject.prototype, 'areAllGapsEmpty'),
             areAllGapsFilled: sinon.stub(this.presenter.GapsContainerObject.prototype, 'areAllGapsFilled'),
-            getStringReconvertedUserExpression: sinon.stub(this.presenter, 'getStringReconvertedUserExpression')
+            getStringReconvertedUserExpression: sinon.stub(this.presenter, 'getStringReconvertedUserExpression'),
+            hideAnswers: sinon.stub(this.presenter, 'hideAnswers'),
+            showAnswers: sinon.stub(this.presenter, 'showAnswers')
         };
 
         this.presenter.gapsContainer = new this.presenter.GapsContainerObject();
@@ -42,6 +44,8 @@ TestCase("[Basic Math Gaps] Score Tests", {
         this.presenter.GapsContainerObject.prototype.areAllGapsEmpty.restore();
         this.presenter.getStringReconvertedUserExpression.restore();
         this.presenter.GapsContainerObject.prototype.areAllGapsFilled.restore();
+        this.presenter.hideAnswers.restore();
+        this.presenter.showAnswers.restore();
     },
 
     'test getScore for equation and valid user input' : function() {
@@ -51,6 +55,8 @@ TestCase("[Basic Math Gaps] Score Tests", {
 
         var score = this.presenter.getScore();
 
+        assertFalse(this.stubs.hideAnswers.called);
+        assertFalse(this.stubs.showAnswers.called);
         assertEquals(1, score);
     },
 
@@ -107,10 +113,23 @@ TestCase("[Basic Math Gaps] Score Tests", {
             '</div>');
 
         this.stubs.getValues.returns(["1", "1"]);
-    this.stubs.getStringReconvertedUserExpression.returns("1+1");
+        this.stubs.getStringReconvertedUserExpression.returns("1+1");
 
         var score = this.presenter.getScore();
 
+        assertEquals(1, score);
+    },
+
+    'test should hide answers if show answers is active and restore after' : function() {
+        this.stubs.getValues.returns(["1", "2"]);
+        this.stubs.getStringReconvertedUserExpression.returns("1+2=3");
+        this.stubs.areAllGapsFilled.returns(true);
+        this.presenter.configuration.isShowAnswersActive = true;
+
+        let score = this.presenter.getScore();
+
+        assertTrue(this.stubs.hideAnswers.calledOnce);
+        assertTrue(this.stubs.showAnswers.calledOnce);
         assertEquals(1, score);
     },
 
@@ -119,7 +138,6 @@ TestCase("[Basic Math Gaps] Score Tests", {
 
         assertEquals(1, maxScore);
     },
-
 
     'test getMaxScore when NOT isEquation' : function() {
         this.presenter.configuration.isEquation = false;

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2026-06-26 Fixed Basic Math Gaps addon not working correctly when Show Answers increments mistake counter
 2023-06-23 Fixed nested addons in Text breaking printing
 2023-06-23 Fixed IWB Toolbar left position when uncheck "Fixed Position" in LMS mCourser
 2023-06-23 Fixed not being able to set page index 0 in alternative page titles property of HLR


### PR DESCRIPTION
[Ticket](https://app.assembla.com/spaces/lorepo/tickets/8830--sejer--bmg---sa-z-increment-mistake-counter-nie-dzia%C5%82a/details)
[Wersja testowa](https://test-8830-dot-mauthor-dev.ew.r.appspot.com/)
[Lekcja testowa](https://test-8830-dot-mauthor-dev.ew.r.appspot.com/present/5208207171518464)

W ramach tego zadania naprawiono dodatkowo poniższy błąd:
*Opis błędu*
Jeżeli strona jest nieraportowana oraz jest aktywne Show Answers to getState (wykonywany podczas przechodzenia między stronami lekcji) zapisuje do stanu wyniki z Show Answers, zamiast tych użytkownika.

*Kroki do reprodukcji*
1. Wejść na stronę https://mauthor-dev.ew.r.appspot.com/present/5208207171518464#2
2. Włączyć Show Answers.
3. Przejść na inną stronę.
4. Wrócić na poprzednią stronę
5. Addon będzie miał zapisany wynik z Show Answers