### PR TITLE
Change label of functionality to sort addons CSS classes in Editor from "Sort" to "Sort A-Z", re #8853

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2023-07-19 Changed label of functionality to sort addons CSS classes in Editor from "Sort" to "Sort A-Z"
 2023-07-07 Fixed interaction of LaTeX in FlashCards
 2023-07-05 Fixed Pragraph styling of the current content affecting Show Answers text
 2023-07-05 Changed CSS editor

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/bl/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/bl/dictionary.js
@@ -245,7 +245,7 @@ var ice_dictionary_bl = {
 	"styles" : "Стилове",
 	"css_class" : "CSS клас:",
 	"inline_css" : "Инлайн CSS:",
-	"styles_sort_label" : "Sort",
+	"styles_sort_label" : "Sort A-Z",
 	"can_not_save_styles_sort_selected": "Can't save CSS class sort preference",
 	"update_style" : "Обновяване на стила",
 	"cant_load_document" : "Документът не може да се зареди: ",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/com/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/com/dictionary.js
@@ -245,7 +245,7 @@ var ice_dictionary_en = {
 	"styles" : "Styles",
 	"css_class" : "CSS class:",
 	"inline_css" : "Inline CSS:",
-	"styles_sort_label" : "Sort",
+	"styles_sort_label" : "Sort A-Z",
 	"can_not_save_styles_sort_selected": "Can't save CSS class sort preference",
 	"update_style" : "Update style",
 	"cant_load_document" : "Can't load document: ",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/fr/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/fr/dictionary.js
@@ -246,7 +246,7 @@ var ice_dictionary_fr = {
     "css_class" : "Classes CSS :",
     "inline_css" : "CSS du module :",
     "styles_sort_label" : "Sort A-Z",
-	"can_not_save_styles_sort_selected": "Can't save CSS class sort preference",
+    "can_not_save_styles_sort_selected": "Can't save CSS class sort preference",
     "update_style" : "Mettre à jour le style",
     "cant_load_document" : "Impossible de charger le document :",
     "cant_add_page" : "Impossible d'ajouter la page :",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/fr/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/fr/dictionary.js
@@ -245,7 +245,7 @@ var ice_dictionary_fr = {
     "styles" : "Styles",
     "css_class" : "Classes CSS :",
     "inline_css" : "CSS du module :",
-    "styles_sort_label" : "Sort",
+    "styles_sort_label" : "Sort A-Z",
 	"can_not_save_styles_sort_selected": "Can't save CSS class sort preference",
     "update_style" : "Mettre à jour le style",
     "cant_load_document" : "Impossible de charger le document :",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/mx/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/mx/dictionary.js
@@ -245,7 +245,7 @@ var ice_dictionary_mx = {
 	"styles": "Estilos",
 	"css_class": "Clase CSS:",
 	"inline_css": "CSS embebido:",
-	"styles_sort_label" : "Sort",
+	"styles_sort_label" : "Sort A-Z",
 	"can_not_save_styles_sort_selected": "Can't save CSS class sort preference",
 	"update_style": "Actualizar estilo",
 	"cant_load_document": "No se puede cargar el documento:",

--- a/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/pl/dictionary.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/dictionaries/pl/dictionary.js
@@ -245,7 +245,7 @@ var ice_dictionary_pl = {
 	"styles" : "Style",
 	"css_class" : "Klasa CSS:",
 	"inline_css" : "CSS wplatany:",
-	"styles_sort_label" : "Sort",
+	"styles_sort_label" : "Sort A-Z",
 	"can_not_save_styles_sort_selected": "Can't save CSS class sort preference",
 	"update_style" : "Aktualizuj styl",
 	"cant_load_document" : "Nie można wczytać dokumentu: ",


### PR DESCRIPTION
[Ticket](https://learneticsa.assembla.com/spaces/lorepo/tickets/8853-zmiana-labelki-w-edytorze/details)
[Wersja testowa](https://test-8853-dot-mauthor-dev.ew.r.appspot.com/)