### PR TITLE
Remove capitalization of letter ß in Magic Boxes, re #8849

### DIFF
--- a/addons/Magic_Boxes/src/presenter.js
+++ b/addons/Magic_Boxes/src/presenter.js
@@ -167,7 +167,9 @@ function AddonMagic_Boxes_create() {
 
                 var selectableElement = $(document.createElement('div'));
                 selectableElement.addClass(presenter.CSS_CLASSES.ELEMENT);
-                selectableElement.text(presenter.configuration.gridElements[row][column].toUpperCase());
+                var rawChar = presenter.configuration.gridElements[row][column];
+                var charToShow = isCharacterToCapitalize(rawChar) ? rawChar.toUpperCase() : rawChar;
+                selectableElement.text(charToShow);
 
                 wrapperElement.append(selectableElement);
                 gridContainer.append(wrapperElement);
@@ -293,6 +295,10 @@ function AddonMagic_Boxes_create() {
                 }
             }
         });
+    }
+
+    function isCharacterToCapitalize (character) {
+        return !(/\u00DF/.test(character));
     }
 
     presenter.calculateScoreForEvent = function (prevScore, currentScore) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2023-07-25 Removed capitalization of letter ß in Magic Boxes
 2023-07-19 Restored page numbering from 1 in Hierarchical Lesson Report
 2023-07-19 Fixed added audio in Choice not working on mobile
 2023-07-19 Fixed the isAllOK function in the Magic Boxes


### PR DESCRIPTION
[Ticket](https://learneticsa.assembla.com/spaces/lorepo/tickets/8849--support--msmstudio--potrzebne-jest-niemieckie-%C3%9F-w-magic-box/details)
Wersja testowa
Lekcja testowa