### PR TITLE
Remove navigation on invisible elements in AudioText addon when TTS or keyboard navigation is active, re #8745

### DIFF
--- a/addons/TextAudio/src/presenter.js
+++ b/addons/TextAudio/src/presenter.js
@@ -2141,7 +2141,7 @@ function AddonTextAudio_create() {
 
     TextAudioKeyboardController.prototype.scrollVertically = function ($textElement) {
         let pos = $textElement.position().top;
-        const $slideWithElement = $textElement.parents().find(`.textaudio-text`);
+        const $slideWithElement = $textElement.closest(`.textaudio-text`);
         const currentScroll = $slideWithElement.scrollTop();
         const divHeight =  $slideWithElement.height();
 

--- a/addons/TextAudio/src/presenter.js
+++ b/addons/TextAudio/src/presenter.js
@@ -2063,7 +2063,7 @@ function AddonTextAudio_create() {
     };
 
     presenter.getElementsForKeyboardNavigation = function () {
-        var elements;
+        let elements;
         switch (presenter.configuration.controls) {
             case controls.CUSTOM:
                 elements = [
@@ -2088,13 +2088,13 @@ function AddonTextAudio_create() {
 
     presenter.actualizeKeyboardControllerElements = function () {
         if (presenter.keyboardControllerObject) {
-            var elements = presenter.getElementsForKeyboardNavigation();
+            const elements = presenter.getElementsForKeyboardNavigation();
             presenter.keyboardControllerObject.setElements(elements);
         }
     };
 
     presenter.buildKeyboardController = function () {
-        var elements = presenter.getElementsForKeyboardNavigation();
+        const elements = presenter.getElementsForKeyboardNavigation();
         presenter.keyboardControllerObject = new TextAudioKeyboardController(elements, 1);
     }
 
@@ -2119,6 +2119,13 @@ function AddonTextAudio_create() {
         this.mapping[window.KeyboardControllerKeys.ARROW_DOWN] = this.down;
     };
 
+    TextAudioKeyboardController.prototype.setElements = function (elements) {
+        KeyboardController.prototype.setElements.call(this, elements);
+        if (this.keyboardNavigationActive) {
+            this.switchWithoutReadingToFirstVisibleElement();
+        }
+    };
+
     TextAudioKeyboardController.prototype.getCurrentElement = function () {
         return $(this.getTarget(this.keyboardNavigationCurrentElement, false));
     };
@@ -2126,13 +2133,33 @@ function AddonTextAudio_create() {
     TextAudioKeyboardController.prototype.mark = function (element) {
         KeyboardController.prototype.mark.call(this, element);
 
-        var $element = this.getCurrentElement();
-
-        $element[0].scrollIntoView();
+        const $currentElement = this.getCurrentElement();
+        if ($currentElement.is('[class^="textelement"]') && this.isElementVisible($currentElement)) {
+            this.scrollVertically($currentElement);
+        }
     };
 
+    TextAudioKeyboardController.prototype.scrollVertically = function ($textElement) {
+        let pos = $textElement.position().top;
+        const $slideWithElement = $textElement.parents().find(`.textaudio-text`);
+        const currentScroll = $slideWithElement.scrollTop();
+        const divHeight =  $slideWithElement.height();
+
+        pos = (pos + currentScroll) - (divHeight / 2);
+
+        $slideWithElement.scrollTop(pos);
+    }
+
     TextAudioKeyboardController.prototype.enter = function (event) {
-        KeyboardController.prototype.enter.call(this, event);
+        if (event) {
+            event.preventDefault();
+        }
+
+        if (!this.keyboardNavigationActive) {
+            this.keyboardNavigationActive = true;
+            this.switchWithoutReadingToFirstVisibleElement();
+        }
+
         if (presenter.isWCAGOn) {
             this.speakCurrentElement();
         }
@@ -2143,18 +2170,18 @@ function AddonTextAudio_create() {
             this.selectedMode = true;
         }
         KeyboardController.prototype.select.call(this, event);
-    }
+    };
 
     TextAudioKeyboardController.prototype.up = function (event) {
         if (event) {
             event.preventDefault();
         }
 
-        var $currentElement = this.getCurrentElement();
+        const $currentElement = this.getCurrentElement();
         if (this.isElementActiveForAfterSelectionAction($currentElement)) {
             presenter.changePlaybackRate(presenter.OPERATION_TYPE.INCREASE);
         } else {
-            this.switchElement(-this.columnsCount);
+            this.previousRow(event);
         }
     };
 
@@ -2163,11 +2190,11 @@ function AddonTextAudio_create() {
             event.preventDefault();
         }
 
-        var $currentElement = this.getCurrentElement();
+        const $currentElement = this.getCurrentElement();
         if (this.isElementActiveForAfterSelectionAction($currentElement)) {
             presenter.changePlaybackRate(presenter.OPERATION_TYPE.DECREASE);
         } else {
-            this.switchElement(this.columnsCount);
+            this.nextRow(event);
         }
     };
 
@@ -2176,15 +2203,88 @@ function AddonTextAudio_create() {
             && this.selectedMode
             && $element.hasClass(presenter.CSS_CLASSES.AUDIO_SPEED_CONTROLLER)
         );
-    }
+    };
+
+    TextAudioKeyboardController.prototype.nextElement = function (event) {
+        if (event) {
+            event.preventDefault();
+        }
+        this.switchElement(1);
+
+        if (!this.isCurrentElementVisible() && !this.isLastVisibleElementEqualsCurrentElement()) {
+            this.nextElement(event);
+        }
+    };
+
+    TextAudioKeyboardController.prototype.previousElement = function (event) {
+        if (event) {
+            event.preventDefault();
+        }
+        this.switchElement(-1);
+
+        if (!this.isCurrentElementVisible() && !this.isLastVisibleElementEqualsCurrentElement()) {
+            this.previousElement(event);
+        }
+    };
+
+    TextAudioKeyboardController.prototype.nextRow = function (event) {
+        if (event) {
+            event.preventDefault();
+        }
+        this.switchElement(this.columnsCount);
+
+        if (!this.isCurrentElementVisible() && !this.isLastVisibleElementEqualsCurrentElement()) {
+            this.nextRow(event);
+        }
+    };
+
+    TextAudioKeyboardController.prototype.previousRow = function (event) {
+        if (event) {
+            event.preventDefault();
+        }
+        this.switchElement(-this.columnsCount);
+
+        if (!this.isCurrentElementVisible() && !this.isLastVisibleElementEqualsCurrentElement()) {
+            this.previousRow(event);
+        }
+    };
+
+    TextAudioKeyboardController.prototype.switchWithoutReadingToFirstVisibleElement = function () {
+        for (let i = 0; i < this.keyboardNavigationElementsLen; i++) {
+            let $nextElement = this.keyboardNavigationElements[i];
+            if (this.isElementVisible($nextElement)) {
+                this.lastVisibleElementIndex = i;
+                this.keyboardNavigationCurrentElementIndex = i;
+                this.keyboardNavigationCurrentElement = $nextElement;
+                this.mark($nextElement);
+                return;
+            }
+        }
+    };
+
+    TextAudioKeyboardController.prototype.isCurrentElementVisible = function () {
+        return this.isElementVisible(this.getCurrentElement());
+    };
+
+    TextAudioKeyboardController.prototype.isElementVisible = function ($element) {
+        const style = window.getComputedStyle($element[0]);
+        return style.display !== 'none' && style.visibility === 'visible';
+    };
+
+    TextAudioKeyboardController.prototype.isLastVisibleElementEqualsCurrentElement = function () {
+        return this.lastVisibleElementIndex === this.keyboardNavigationCurrentElementIndex;
+    };
 
     TextAudioKeyboardController.prototype.switchElement = function (move) {
         this.selectedMode = false;
         KeyboardController.prototype.switchElement.call(this, move);
-        if (presenter.isWCAGOn) {
-            this.speakCurrentElement();
+        if (this.isCurrentElementVisible()) {
+            this.lastVisibleElementIndex = this.keyboardNavigationCurrentElementIndex;
+            if (presenter.isWCAGOn) {
+                this.speakCurrentElement();
+            }
         }
-    }
+    };
 
     TextAudioKeyboardController.prototype.escape = function (event) {
         presenter.pause();
@@ -2202,7 +2302,7 @@ function AddonTextAudio_create() {
     };
 
     TextAudioKeyboardController.prototype.speakCurrentElement = function () {
-        var $currentElement = this.getCurrentElement();
+        const $currentElement = this.getCurrentElement();
 
         if ($currentElement.hasClass(presenter.CSS_CLASSES.PLAY_PAUSE_BUTTON)) {
             this.speakForPlayPauseButton();
@@ -2229,12 +2329,12 @@ function AddonTextAudio_create() {
     };
 
     function speakMessage(message) {
-        var speechTextVoices = [TTSUtils.getTextVoiceObject(message)];
+        const speechTextVoices = [TTSUtils.getTextVoiceObject(message)];
         presenter.speak(speechTextVoices);
     }
 
     presenter.speak = function (data) {
-        var tts = presenter.getTextToSpeechOrNull(presenter.playerController);
+        const tts = presenter.getTextToSpeechOrNull(presenter.playerController);
         if (tts && presenter.isWCAGOn) {
             tts.speak(data);
         }

--- a/addons/TextAudio/test/KeyboardControllerTests.js
+++ b/addons/TextAudio/test/KeyboardControllerTests.js
@@ -118,6 +118,7 @@ TestCase("[TextAudio] Keyboard controller and TTS activation tests", {
             speakCurrentElementStub: sinon.stub(),
             selectActionStub: sinon.stub(),
             changePlaybackRateStub: sinon.stub(),
+            isCurrentElementVisibleStub: sinon.stub()
         };
 
         let elements = this.getElementsForKeyboardNavigation();
@@ -130,6 +131,9 @@ TestCase("[TextAudio] Keyboard controller and TTS activation tests", {
         this.presenter.changePlaybackRate = this.stubs.changePlaybackRateStub;
         this.keyboardControllerObject.speakCurrentElement = this.stubs.speakCurrentElementStub;
         this.keyboardControllerObject.selectAction = this.stubs.selectActionStub;
+
+        this.stubs.isCurrentElementVisibleStub.returns(true);
+        this.keyboardControllerObject.isCurrentElementVisible = this.stubs.isCurrentElementVisibleStub;
 
         this.spies = {
             switchElementSpy: sinon.spy(this.keyboardControllerObject, 'switchElement'),
@@ -578,6 +582,32 @@ TestCase("[TextAudio] Keyboard controller and TTS activation tests", {
 
         this.validateIfOnlySlideHasKeyboardNavigationActiveClass();
     },
+
+    'test given view, keyboard navigation is active and all elements are hidden when activated tab then move on every element and stop after' : function() {
+        this.activateKeyboardNavigation();
+        this.moveToPlayButton();
+        this.stubs.isCurrentElementVisibleStub.returns(false);
+        this.keyboardControllerObject.lastVisibleElementIndex = 0
+
+        activateTabEvent(this.presenter);
+
+        this.verifyIfNotExecutedReadMethod();
+        assertEquals(this.spies.switchElementSpy.callCount, this.keyboardControllerObject.keyboardNavigationElementsLen);
+        assertEquals(this.keyboardControllerObject.lastVisibleElementIndex, this.keyboardControllerObject.keyboardNavigationCurrentElementIndex);
+    },
+
+    'test given view, TTS navigation is active and all elements are hidden when activated tab then move on every element and stop after' : function() {
+        this.activateTTSWithoutReading();
+        this.moveToPlayButton();
+        this.stubs.isCurrentElementVisibleStub.returns(false);
+        this.keyboardControllerObject.lastVisibleElementIndex = 0
+
+        activateTabEvent(this.presenter);
+
+        this.verifyIfNotExecutedReadMethod();
+        assertEquals(this.spies.switchElementSpy.callCount, this.keyboardControllerObject.keyboardNavigationElementsLen);
+        assertEquals(this.keyboardControllerObject.lastVisibleElementIndex, this.keyboardControllerObject.keyboardNavigationCurrentElementIndex);
+    }
 });
 
 function hasKeyboardNavigationActiveElementClass($element) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2023-08-29 Removed navigation on invisible elements in AudioText addon when TTS or keyboard navigation is active
 2023-08-25 Correct calculating gap width
 2023-08-25 Fixed issue with show answers mode in Table+Math
 2023-08-25 Fixed reset in Paragraph to restore original visibility


### PR DESCRIPTION
[Ticket](https://learneticsa.assembla.com/spaces/lorepo/tickets/8754--textaudio--tts-czyta-ukryty-przycisk--quot-stop-quot-/details)
[Wersja testowa](https://test-8754-dot-mauthor-dev.ew.r.appspot.com)
[Lekcja testowa](https://test-8754-dot-mauthor-dev.ew.r.appspot.com/present/5079876484726784)
[Lekcja testowa 2](https://test-8754-dot-mauthor-dev.ew.r.appspot.com/present/5135449066569728)
[Lekcja testowa z opisu](https://test-8754-dot-mauthor-dev.ew.r.appspot.com/present/6117546153476096#8)