### PR TITLE
Fixed mathjax issue in Text when a page has been reloaded in quick succession, re #8906

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2023-09-27 Fixed mathjax issue in Text when a page has been reloaded in quick succession
 2023-09-13 Fixed sending event after leaving gap when TTS is activated
 2023-09-13 Fixed skipping sentence after special characters
 2023-09-13 Fixed reading hidden elements in the EditableWindow

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
@@ -213,8 +213,14 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 		}
 	}
 
+	private native boolean isElementContainedInBody(Element e)/*-{
+		return $doc.body.contains(e);
+	}-*/;
+
 	@Override
 	public void connectMathGap(Iterator<GapInfo> giIterator, String id, ArrayList<Boolean> savedDisabledState) {
+		// Stop if Text view is no longer part of the DOM
+		if (!isElementContainedInBody(getElement())) return;
 		while (giIterator.hasNext()) {
 			GapInfo gi = giIterator.next();
 			if (gi.getId().equals(id)) {


### PR DESCRIPTION
ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/8906-icplayer-nie-mo%C5%BCe-stworzy%C4%87-modu%C5%82u/details?comment=1708459817
wersja testowa: https://test-8906-dot-mauthor-dev.ew.r.appspot.com/embed/6250403853238272#2

Jak przetestować:
wejdź na powyższy link i wykonaj w konsoli poniższą komendę:
setTimeout(function(){player.getPlayerServices().getCommands().gotoPageIndex(2);},0);
setTimeout(function(){player.getPlayerServices().getCommands().gotoPageIndex(2);},0);
Pamiętaj, żeby być w odpowiednim kontekście.