### PR TITLE
Fix too early launch of blur feedback when using eKeyboard on mobile devices, re #8899

### DIFF
--- a/addons/eKeyboard/src/presenter.js
+++ b/addons/eKeyboard/src/presenter.js
@@ -375,6 +375,7 @@ function AddoneKeyboard_create(){
                             var $el = $(element);
                             $el.addClass('ui-keyboard-lockedinput');
                             $el.attr('readonly', true);
+                            $el.attr('inputmode', "none");
                         }
                     );
                 }
@@ -431,10 +432,6 @@ function AddoneKeyboard_create(){
             openButtonElement.style.display = 'block';
             actualizeOpenButtonPosition($(lastClickedElement));
         } else {
-            if (MobileUtils.isMobileUserAgent(navigator.userAgent) && presenter.configuration.lockInput) {
-                // hides native keyboard
-                document.activeElement.blur();
-            }
             presenter.createEKeyboard(this, presenter.display);
             $(this).trigger('showKeyboard');
         }
@@ -493,6 +490,7 @@ function AddoneKeyboard_create(){
 
         $(closeButtonElement).hide();
         $(lastClickedElement).removeAttr("readonly");
+        $(lastClickedElement).removeAttr("inputmode");
         var keyboard = $(lastClickedElement).data('keyboard');
         if (keyboard !== undefined) {
             keyboard.accept();
@@ -800,7 +798,7 @@ function AddoneKeyboard_create(){
 
     function showOpenButtonCallback() {
         hideOpenButton();
-
+        presenter.configuration.$inputs.attr("inputmode", "none");
         presenter.enable();
 
         escClicked = false;
@@ -919,6 +917,7 @@ function AddoneKeyboard_create(){
         presenter.configuration.$inputs.on('focusout', focusoutCallBack);
         presenter.configuration.$inputs.removeClass('ui-keyboard-input ui-keyboard-input-current');
         presenter.configuration.$inputs.removeAttr("readonly");
+        presenter.configuration.$inputs.removeAttr("inputmode");
     };
 
     presenter.enable = function () {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2023-10-30 Fixed too early launch of blur feedback when using eKeyboard on mobile devices
 2023-10-27 Fixed recording malfunction on application
 2023-10-27 Fixed checking correctness of drawing in Shape Tracing for scaled player
 2023-10-27 Removed re-downloading of lesson page XML when changing layout


### PR DESCRIPTION
[Ticket](https://learneticsa.assembla.com/spaces/lorepo/tickets/8899--support--smart-education-tr--klikni%C4%99cie-literki-w-module-ekeyboard-uruchamia/details)
[Wersja testowa](https://test-8899-dot-mauthor-dev.ew.r.appspot.com)
[Lekcja testowa 1 - z zadania](https://test-8899-dot-mauthor-dev.ew.r.appspot.com/present/6545135951151104#2). Na stronie 3 dodałem event listener i wyłączyłem warunek z szerokością ekranu.
[Lekcja testowa 2](https://mauthor-dev.ew.r.appspot.com/present/6494546135351296#6)