### PR TITLE
Change Image Identification addon to set 'Alternative text' as 'alt' attribute, re #8953

### DIFF
--- a/addons/Image_Identification/src/presenter.js
+++ b/addons/Image_Identification/src/presenter.js
@@ -138,13 +138,18 @@ function AddonImage_Identification_create(){
 
     function loadImage(imageSrc, isPreview) {
         var image = document.createElement('img');
-        $(image).attr('src', imageSrc);
-        $(image).addClass(presenter.configuration.isSelected ? CSS_CLASSES.SELECTED : CSS_CLASSES.ELEMENT);
+        var $image = $(image);
+        $image.attr('src', imageSrc);
+        $image.addClass(presenter.configuration.isSelected ? CSS_CLASSES.SELECTED : CSS_CLASSES.ELEMENT);
         presenter.$view.html(image);
 
         presenter.setVisibility(presenter.configuration.isVisibleByDefault || isPreview);
 
-        $(image).load(function () {
+        if (presenter.configuration.altText !== undefined) {
+            $image.attr("alt", presenter.configuration.altText);
+        }
+
+        $image.load(function () {
             var elementDimensions = DOMOperationsUtils.getOuterDimensions(this);
             var elementDistances = DOMOperationsUtils.calculateOuterDistances(elementDimensions);
 
@@ -165,10 +170,6 @@ function AddonImage_Identification_create(){
                 height:$(element).height() + 'px',
                 color: 'rgba(0,0,0,0.0)'
             });
-
-            if(presenter.configuration.altText !== undefined) {
-                $(innerElement).html(presenter.configuration.altText);
-            }
 
             $(element).html(innerElement);
             presenter.$view.html(element);

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2023-11-13 Change Image Identification to set 'Alternative text' as 'alt' attribute
 2023-11-08 Added Gradual Show Answers to Connecting Dots
 2023-11-08 Fixed alt text in Connection addon
 2023-11-08 Fixed displaying geometric devices in IWB Toolbar

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-2023-11-13 Change Image Identification to set 'Alternative text' as 'alt' attribute
+2023-11-13 Changed Image Identification to set 'Alternative text' as 'alt' attribute
 2023-11-08 Added Gradual Show Answers to Connecting Dots
 2023-11-08 Fixed alt text in Connection addon
 2023-11-08 Fixed displaying geometric devices in IWB Toolbar


### PR DESCRIPTION
[Ticket](https://learneticsa.assembla.com/spaces/lorepo/tickets/8953--support--pearson-global--d%C5%82u%C5%BCszy---39-alternative-text--39--w-module-/details)
[Wersja testowa](https://test-8953-dot-mauthor-dev.ew.r.appspot.com)
[Lekcja testowa](https://test-8953-dot-mauthor-dev.ew.r.appspot.com/present/5797781576876032)
[Lekcja testowa 2](https://test-8953-dot-mauthor-dev.ew.r.appspot.com/present/4582460350267393)

Na produkcji jak i na tej wersji nie przechodzi 9 na 24 testy. Wszystkie powiązane z drukowalną wersją. Testy te nigdy nie przechodziły na produkcji. Podczas realizacji zadania oraz dodawania testów musiała być poprawka w kodzie ale testy wtedy nie zostały dopasowane.