### PR TITLE
Change position on collision of eKeyboard from flip to flipfit, re #8957

### DIFF
--- a/addons/eKeyboard/src/presenter.js
+++ b/addons/eKeyboard/src/presenter.js
@@ -512,7 +512,7 @@ function AddoneKeyboard_create(){
                 at : presenter.configuration.positionAt.value,
                 at2 : presenter.configuration.positionAt.value,
                 offset : presenter.configuration.offset.value,
-                collision: 'flipfit'
+                collision: 'fit'
             },
 
                     // preview added above keyboard if true, original input/textarea used if false

--- a/addons/eKeyboard/src/presenter.js
+++ b/addons/eKeyboard/src/presenter.js
@@ -512,7 +512,7 @@ function AddoneKeyboard_create(){
                 at : presenter.configuration.positionAt.value,
                 at2 : presenter.configuration.positionAt.value,
                 offset : presenter.configuration.offset.value,
-                collision: 'flip'
+                collision: 'flipfit'
             },
 
                     // preview added above keyboard if true, original input/textarea used if false

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2023-11-13 Changed position on collision of eKeyboard from flip to flipfit
 2023-11-08 Added Gradual Show Answers to Connecting Dots
 2023-11-08 Fixed alt text in Connection addon
 2023-11-08 Fixed displaying geometric devices in IWB Toolbar


### PR DESCRIPTION
[Ticket](https://learneticsa.assembla.com/spaces/lorepo/tickets/8957--support--laivdata--modu%C5%82-ekeyboard-wychodzi-poza-stron%C4%99/details)
[Wersja testowa](https://test-8957-dot-mauthor-dev.ew.r.appspot.com/)
[Lekcja testowa](https://test-8957-dot-mauthor-dev.ew.r.appspot.com/present/6503315753926657)
[Lekcja testowa 2](https://test-8957-dot-mauthor-dev.ew.r.appspot.com/present/6545135951151104#2)

Wytłumaczenie:
Addon korzysta z biblioteki jQuery UI Virtual Keyboard.
Do konfiguracji addonu można podać parametry w tym [pozycje](https://api.jqueryui.com/1.8/position/). W związku, z tym że poprzednie ustawienie dla "collision" było "flip", to jedyna inna konfiguracja to "fit". W tickecie opisałem inne rozwiazania/kroki, gdyby te rozwiązanie nie było wystarczające. Gdyby miała być aktualizowana biblioteka jQuery UI to nie jest potrzeba aktualizacji biblioteki klawiatury, gdyż ma ona wystarczającą wersję.