### PR TITLE
Fixed Text receiving nowrap style when not apropriate, re #8959

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2023-12-01 Fixed Text receiving nowrap style when not apropriate
 2023-11-23 Added support for paragraphInitDelay external variable in the Paragraph addon
 2023-11-23 Fixed inability to select text when there is slider addon on page
 2023-11-23 Expanded functionality for the text editor in the Drawing addon

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
@@ -8,7 +8,6 @@ import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.HTML;
-import com.lorepo.icf.utils.JavaScriptUtils;
 import com.lorepo.icf.utils.StringUtils;
 import com.lorepo.icf.utils.TextToSpeechVoice;
 import com.lorepo.icf.utils.i18n.DictionaryWrapper;
@@ -249,8 +248,12 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 	private void updateParentProperty(Element child) {
 		com.google.gwt.dom.client.Element parentElement = child.getParentElement();
 
-		if (parentElement !=null ) {
-			parentElement.getStyle().setProperty("text-wrap", "nowrap");
+		if (parentElement !=null) {
+			double childWidth = child.getClientWidth();
+			double parentWidth = parentElement.getClientWidth();
+			if (parentWidth == 0.0 || childWidth / parentWidth > 0.5) {
+				parentElement.getStyle().setProperty("text-wrap", "nowrap");
+			}
 		}
 	}
 

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
@@ -44,6 +44,7 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 	private String originalDisplay = "";
 	private boolean isPreview = false;
 	private double widthGapMultiplier = 2.5;
+	private int unwrappedViewWidth = 0;
 
 	// active index of navigation text elements (including links). The order follows the order of navigation elements.
 	private int keyboardNavigationCurrentElementIndex = -1;
@@ -250,8 +251,8 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 
 		if (parentElement !=null && getGapChildrenCount(parentElement) == 1 && !containsNewLine(parentElement)) {
 			double childWidth = child.getClientWidth();
-			double parentWidth = parentElement.getClientWidth();
-			if (parentWidth == 0.0 || childWidth / parentWidth > 0.7) {
+			double viewWidth = getViewUnwrappedWidth();
+			if (viewWidth == 0.0 || childWidth / viewWidth > 0.7) {
 				parentElement.getStyle().setProperty("text-wrap", "nowrap");
 			}
 		}
@@ -265,6 +266,22 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 	private native boolean containsNewLine(com.google.gwt.dom.client.Element parent)/*-{
 		var $parent = $wnd.$(parent);
 		return $parent.find('br, div').length > 0;
+	}-*/;
+
+	private int getViewUnwrappedWidth() {
+		if (unwrappedViewWidth == 0) unwrappedViewWidth = getViewUnwrappedWidth(this.getElement());
+		return unwrappedViewWidth;
+	}
+
+	private native int getViewUnwrappedWidth (com.google.gwt.dom.client.Element view)/*-{
+		var $view = $wnd.$(view);
+		var $viewCopy = $view.clone();
+		$viewCopy.css('visibility', 'hidden');
+		$viewCopy.css('width', '');
+		$viewCopy.insertAfter($view);
+		var unwrappedWidth = $viewCopy[0].offsetWidth;
+		$viewCopy.remove();
+		return unwrappedWidth;
 	}-*/;
 
 	@Override

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
@@ -248,14 +248,24 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 	private void updateParentProperty(Element child) {
 		com.google.gwt.dom.client.Element parentElement = child.getParentElement();
 
-		if (parentElement !=null) {
+		if (parentElement !=null && getGapChildrenCount(parentElement) == 1 && !containsNewLine(parentElement)) {
 			double childWidth = child.getClientWidth();
 			double parentWidth = parentElement.getClientWidth();
-			if (parentWidth == 0.0 || childWidth / parentWidth > 0.5) {
+			if (parentWidth == 0.0 || childWidth / parentWidth > 0.7) {
 				parentElement.getStyle().setProperty("text-wrap", "nowrap");
 			}
 		}
 	}
+
+	private native int getGapChildrenCount(com.google.gwt.dom.client.Element parent)/*-{
+		var $parent = $wnd.$(parent);
+		return $parent.find('select, input').length;
+	}-*/;
+
+	private native boolean containsNewLine(com.google.gwt.dom.client.Element parent)/*-{
+		var $parent = $wnd.$(parent);
+		return $parent.find('br, div').length > 0;
+	}-*/;
 
 	@Override
 	public void connectMathGap(Iterator<GapInfo> giIterator, String id, ArrayList<Boolean> savedDisabledState) {


### PR DESCRIPTION
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/8959--support--text--b%C5%82%C4%99dne-dzia%C5%82anie---39-gap-width-0--39--w-module-tex/details
Wersja testowa
mA-dev: https://test-8959-dot-mauthor-dev.ew.r.appspot.com/present/5429321063727105
lc: https://test-8959-dot-lorepocorporate.appspot.com/present/5120523383472128

Problematyczna lekcja, w związku z którą został oryginalnie dodany nowrap (bez niego część gap jest w oddzielnym wierszu od swojego numeru): https://test-8959-dot-mauthor-dev.ew.r.appspot.com/present/5915092937867265#61

