### PR TITLE
Fixed show answers mode not being restored in Text math gaps, re #8960

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2023-12-05 Fixed show answers mode not being restored in Text math gaps
 2023-11-23 Fixed width calculation in Ordering module when "Even width for all elements" is checked
 2023-11-23 Added support for paragraphInitDelay external variable in the Paragraph addon
 2023-11-23 Fixed inability to select text when there is slider addon on page

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
@@ -1499,6 +1499,7 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
 					var currentPageStamp = x.@com.lorepo.icplayer.client.module.text.TextPresenter::getPageStamp()();
 					if (pageStamp === currentPageStamp) {
 						x.@com.lorepo.icplayer.client.module.text.TextPresenter::connectMathGap(Ljava/lang/String;)(id);
+						x.@com.lorepo.icplayer.client.module.text.TextPresenter::restoreGapMode()();
 					}
 					$wnd.MathJax.Hub.signal.hooks["End Process"].Remove(hook);
 				});
@@ -1507,6 +1508,12 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
 			console.log("Error : " + err);
 		}
 	}-*/;
+
+	private void restoreGapMode() {
+		if (this.isShowErrorsMode) {
+			this.setShowErrorsMode();
+		}
+	}
 	
 	private String getPageStamp() {
 		return this.playerServices.getCommands().getPageStamp();


### PR DESCRIPTION
ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/8960--support--a-grade-ahead--limited-check-z-maintain-state-ma-problem-z-gapami/details
wersja testowa: https://test-8960-dot-mauthor-dev.ew.r.appspot.com/present/5573879797907457#2