### PR TITLE
Changed player-utils to include max-score for unvisited pages, re #9066

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2024-01-15 Changed player-utils to provide max score for unvisited pages
 2024-01-11 Fixed issue with LaTeX in Flash Card rendering differently at the front and back of the card
 2024-01-11 Added GSA to the Fractions addon
 2024-01-11 Added GSA support to Figure Drawing addon

--- a/src/main/java/com/lorepo/icplayer/client/model/page/Page.java
+++ b/src/main/java/com/lorepo/icplayer/client/model/page/Page.java
@@ -190,6 +190,10 @@ public class Page extends BasicPropertyProvider implements IStyledModule, IPage,
 			return x.@com.lorepo.icplayer.client.model.page.Page::getPageWeight()();
 		}
 
+		page.getModulesMaxScore = function() {
+			return x.@com.lorepo.icplayer.client.model.page.Page::getModulesMaxScore()();
+		}
+
 		return page;
 	}-*/;
 

--- a/src/main/java/com/lorepo/icplayer/public/libs/player-utils.js
+++ b/src/main/java/com/lorepo/icplayer/public/libs/player-utils.js
@@ -100,7 +100,7 @@
                         "page_id": page.getId(),
                         "score": Math.round(pageScaledScore * 100) / 100,
                         "absolute_score": score['score'],
-                        "max_score": score['maxScore'],
+                        "max_score": score['maxScore'] ? score['maxScore'] : page.getModulesMaxScore(),
                         "errors_count": score['errorCount'] ? score['errorCount'] : 0,
                         "checks_count": score['checkCount'] ? score['checkCount'] : 0,
                         "mistake_count": score['mistakeCount'] ? score['mistakeCount'] : 0,


### PR DESCRIPTION
ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/9066--player--analiza-wysy%C5%82ki-pola-max_score-w-paginatedresult-przy-zapisie-wyniku/details
PR: https://test-9066-dot-mauthor-dev.ew.r.appspot.com/