### PR TITLE
fix(addons): displaying answers in Draggable Gap while GSA is activated, re #9022

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2024-01-17 Fixed inappropriate answers displaying in Draggable Gap while GSA is activated
 2024-01-11 Fixed issue with LaTeX in Flash Card rendering differently at the front and back of the card
 2024-01-11 Added GSA to the Fractions addon
 2024-01-11 Added GSA support to Figure Drawing addon

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
@@ -232,6 +232,7 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
 		TextElementDisplay gap = view.getActivity(itemIndex);
 		if (gap != null) {
 			gap.showAnswers();
+			view.refreshMath();
 		}
 	}
 


### PR DESCRIPTION
[ticket](https://learneticsa.assembla.com/spaces/lorepo/tickets/realtime_cardwall?ticket=9022)
[Wersja testowa](https://test-9022-dot-mauthor-dev.ew.r.appspot.com)
[Lekcja](https://test-9022-dot-mauthor-dev.ew.r.appspot.com/present/5806969149456385?teacher=true)