### PR TITLE
Added static position for Section in ANB, re #9053

### DIFF
--- a/addons/Assessments_Navigation_Bar/documentation.md
+++ b/addons/Assessments_Navigation_Bar/documentation.md
@@ -12,19 +12,24 @@ are randomly assigned to a button. The random sequence is chosen only once when 
     </tr>
     <tr>
         <td>Sections</td>
-        <td>Allows user to specify the sections to be shown by the module. Every section is new line separated and looks as follows:
-        <p>"sectionStart-SectionEnd; SectionName; page1Name, page2Name, page3Name" </p>
+        <td>
+            Allows user to specify the sections to be shown by the module. Every section is new line separated and looks as follows:
+            <p>"sectionStart-SectionEnd; SectionName; page1Name, page2Name, page3Name; pagesCSSClassName1, pagesCSSClassName2; staticPosition" </p>
 
-            <p>for e.g "1-5;; 1, 1, 1, 1, 1" will create one section of
-            5 pages with no section name; every button of the section will have description 1.
-                </p>
+            <p>for e.g "1-5;; 1, 1, 1, 1, 1; customCSSClassName1, customCSSClassName2" will create one section of
+            5 pages with no section name; 
+			every button of the section will have description 1; 
+			every button of the section will have `customCSSClassName1` and `customCSSClassName2` CSS classes.
+            </p>
+
+            <p>staticPosition should be either "left" or "right". If provided, the section with this value will always be displayed on either left or right side of the addon, regardless of what pages are being displayed at the moment.</p>
 
             <br>Section start and section end may also be comma separated indexes.
 
-            Only section start and end are required, section name and page descriptions are optional.
+            Only section start and end are required. Section name, page descriptions and pages CSS class names are optional.
             Remember to put only valid section start and section end to the section property. Providing numbers larger than the number of presentation pages may cause improper working of the addon.
 
-            By default,, the section descriptions are page numbers provided in section start and section end.
+            By default, the section descriptions are page numbers provided in section start and section end.
         </td>
     </tr>
     <tr>

--- a/addons/Assessments_Navigation_Bar/src/presenter.js
+++ b/addons/Assessments_Navigation_Bar/src/presenter.js
@@ -1535,7 +1535,7 @@ function AddonAssessments_Navigation_Bar_create(){
         }
 
         if (len > 3) {
-            if (len <= 4 || getTrimmedStringElement(section[4]).length == 0) {
+            if (len <= 4 || getTrimmedStringElement(section[3]).length != 0) {
                 sectionButtonsCssClassNames = presenter.parseSectionButtonsCssClassNames(section[3], (sectionIndex + 1));
                 if (!sectionButtonsCssClassNames.isValid) {
                     return sectionButtonsCssClassNames;

--- a/addons/Assessments_Navigation_Bar/src/presenter.js
+++ b/addons/Assessments_Navigation_Bar/src/presenter.js
@@ -20,6 +20,7 @@ function AddonAssessments_Navigation_Bar_create(){
         S_10: "Buttons width property have to be an integer",
         S_11: "Pages CSS classes are invalid on section: %section% in sections property. Number of CSS classes is too small.",
         S_12: "Pages CSS classes are invalid on section: %section% in sections property. At least one of CSS classes is invalid.",
+        S_13: "Static position value in section %section% is invalid: the value must be 'left', 'right', or left empty."
     };
 
     presenter.DEFAULT_TTS_PHRASES = {
@@ -974,7 +975,11 @@ function AddonAssessments_Navigation_Bar_create(){
                 if (page.staticPosition == 'left') {
                     presenter.$view.find('.navigation-buttons-first .previous').after($section);
                 } else {
-                    presenter.$view.find('.navigation-buttons-last .next').before($section);
+                    if (presenter.$view.find('.navigation-buttons-last .section').length == 0) {
+                        presenter.$view.find('.navigation-buttons-last .next').before($section);
+                    } else {
+                        presenter.$view.find('.navigation-buttons-last .section').first().before($section);
+                    }
                 }
             } else {
                 $section = staticSections[sectionName];
@@ -1547,6 +1552,9 @@ function AddonAssessments_Navigation_Bar_create(){
             var rawPosition = getTrimmedStringElement(section[4]).toLowerCase();
             if (rawPosition == 'left') staticPosition = 'left';
             if (rawPosition == 'right') staticPosition = 'right';
+            if (rawPosition.length > 0 && staticPosition.length == 0) {
+                return getErrorObject("S_13", {section: sectionIndex});
+            }
         }
 
         return {

--- a/addons/Assessments_Navigation_Bar/test/ModelValidationTests.js
+++ b/addons/Assessments_Navigation_Bar/test/ModelValidationTests.js
@@ -101,7 +101,8 @@ TestCase("[Assessments_Navigation_Bar] Sections validation", {
                     pages: [0, 1, 2, 3],
                     sectionName: "latweZadania",
                     pagesDescriptions: ["1", "2", "3", "4"],
-                    sectionButtonsCssClassNames: ["AClass", "BClass"]
+                    sectionButtonsCssClassNames: ["AClass", "BClass"],
+                    staticPosition: ""
                 }
             ]
         };
@@ -384,7 +385,8 @@ TestCase("[Assessments Navigation Bar] validateModel", {
             validateSections: sinon.stub(this.presenter, 'validateSections'),
             parseButtonsNumber: sinon.stub(this.presenter, 'parseButtonsNumber'),
             parseButtonsWidth: sinon.stub(this.presenter, 'parseButtonsWidth'),
-            calculateNumberOfPages: sinon.stub(this.presenter, 'calculateNumberOfPages')
+            calculateNumberOfPages: sinon.stub(this.presenter, 'calculateNumberOfPages'),
+            calculateNumberOfStaticPages: sinon.stub(this.presenter, 'calculateNumberOfStaticPages')
         }
     },
 
@@ -393,6 +395,7 @@ TestCase("[Assessments Navigation Bar] validateModel", {
         this.presenter.parseButtonsNumber.restore();
         this.presenter.parseButtonsWidth.restore();
         this.presenter.calculateNumberOfPages.restore();
+        this.presenter.calculateNumberOfStaticPages.restore();
     },
 
     'test should validate and parse all properties': function () {
@@ -407,6 +410,8 @@ TestCase("[Assessments Navigation Bar] validateModel", {
         this.stubs.parseButtonsWidth.returns({
             isValid: true
         });
+
+        this.stubs.calculateNumberOfStaticPages.returns(0);
 
         this.presenter.validateModel({});
 
@@ -467,7 +472,8 @@ TestCase("[Assessments Navigation Bar] Model Validation", {
                     pages: [0, 1, 2, 3],
                     sectionName: "latweZadania",
                     pagesDescriptions: ["1", "2", "3", "4"],
-                    sectionButtonsCssClassNames: ["AClass", "BClass"]
+                    sectionButtonsCssClassNames: ["AClass", "BClass"],
+                    staticPosition: ""
                 }
             ],
             addClassAreAllAttempted: true,
@@ -475,7 +481,8 @@ TestCase("[Assessments Navigation Bar] Model Validation", {
             userButtonsNumber: 3,
             userButtonsWidth: 40,
             numberOfPages: 4,
-            defaultOrder: true
+            defaultOrder: true,
+            numberOfStaticPages: 0
         };
     },
 

--- a/addons/Assessments_Navigation_Bar/test/NavigationManagerTests.js
+++ b/addons/Assessments_Navigation_Bar/test/NavigationManagerTests.js
@@ -111,9 +111,10 @@ TestCase("[Assessments_Navigation_Bar] [NavigationManager] Add sections", {
         this.expectedPages = [1, 2, 3];
 
         this.sectionsMock = {
-            getPages: function () {return [1, 2, 3];}
+            getPages: function () {return [1, 2, 3];},
+            getStaticPages: sinon.stub(this.presenter.Sections.prototype, 'getStaticPages')
         };
-
+        this.sectionsMock.getStaticPages.returns([]);
         this.presenter.sections = this.sectionsMock;
 
         this.stubs = {
@@ -123,6 +124,7 @@ TestCase("[Assessments_Navigation_Bar] [NavigationManager] Add sections", {
             addButtonToSection: sinon.stub(this.presenter.NavigationManager.prototype, 'addButtonToSection'),
             appendSectionsToView: sinon.stub(this.presenter.NavigationManager.prototype, 'appendSectionsToView'),
             deactivateNavigationButtons: sinon.stub(this.presenter.NavigationManager.prototype, 'deactivateNavigationButtons'),
+            appendStaticPages: sinon.stub(this.presenter.NavigationManager.prototype, 'appendStaticPages'),
         };
 
         this.navigation = new this.presenter.NavigationManager(0);
@@ -135,6 +137,7 @@ TestCase("[Assessments_Navigation_Bar] [NavigationManager] Add sections", {
         this.presenter.NavigationManager.prototype.addButtonToSection.restore();
         this.presenter.NavigationManager.prototype.appendSectionsToView.restore();
         this.presenter.NavigationManager.prototype.deactivateNavigationButtons.restore();
+        this.presenter.NavigationManager.prototype.appendStaticPages.restore();
     },
 
     'test should set actualPages attribute to pages received from getPages': function () {

--- a/addons/Assessments_Navigation_Bar/test/StatesTests.js
+++ b/addons/Assessments_Navigation_Bar/test/StatesTests.js
@@ -150,7 +150,8 @@ TestCase("[Assessments_Navigation_Bar] UpgradeState", {
                 sectionName: "test section name",
                 sectionClassName: "test section ccs classname",
                 buttonCssClassNames: [],
-                isBookmarkOn: true
+                isBookmarkOn: true,
+                staticPosition: ""
             }],
             attemptedPages: []
         };
@@ -180,7 +181,8 @@ TestCase("[Assessments_Navigation_Bar] UpgradeState", {
                 sectionName: "test section name",
                 sectionClassName: "test section ccs classname",
                 buttonCssClassNames: ["AClass", "BClass"],
-                isBookmarkOn: true
+                isBookmarkOn: true,
+                staticPosition: ""
             }],
             attemptedPages: [1, 2, 3]
         };

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2024-01-23 Added the option of creating static sections in Assessments Navigation Bar
 2024-01-11 Fixed issue with LaTeX in Flash Card rendering differently at the front and back of the card
 2024-01-11 Added GSA to the Fractions addon
 2024-01-11 Added GSA support to Figure Drawing addon


### PR DESCRIPTION
ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/9053-anb-%E2%80%93%C2%A0dodanie-mo%C5%BCliwo%C5%9Bci-okre%C5%9Blenia-stale-widocznych-przycis/details?comment=1710721585
wersja testowa: https://test-9053-dot-mauthor-dev.ew.r.appspot.com/present/4732662268821505

Aby sekcja stale się wyświetlała, należy dodać po średniku wartość left albo right. Przykładowo:
1;;1;cover;left
sprawi, że sekcja zawierająca stronę 1 ze stylem cover będzie się zawsze wyświetlać po lewej stronie addonu.