### PR TITLE
Fixed issue with Text module's math gaps in GSA, re #9060

### DIFF
--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
@@ -245,8 +245,10 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
 			child.reset();
 		}
 
+		isShowAnswersActive = true;
 		setState(this.currentState);
-		
+		isShowAnswersActive = false;
+
 		isVisible = isVisibleBeforeSetState;
 		if (isVisibleBeforeSetState) {
 			view.show(false);
@@ -469,6 +471,8 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
 
 		if (module.hasMathGaps() && !isShowAnswersActive) {
 			view.setHTML(module.parsedText);
+			view.refreshMath();
+			((TextView) view).reconnectHandlers();
 		}
 
 		HashMap<String, String> droppedElements = null;

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
@@ -581,6 +581,7 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 	@Override
 	public void refreshMath () {
 		MathJax.refreshMathJax(getElement());
+		this.reconnectHandlers();
 	}
 
 	@Override

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
@@ -581,7 +581,6 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 	@Override
 	public void refreshMath () {
 		MathJax.refreshMathJax(getElement());
-		this.reconnectHandlers();
 	}
 
 	@Override
@@ -618,7 +617,7 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 		}
 	}
 
-	private void reconnectHandlers () {
+	public void reconnectHandlers () {
 		for (GapWidget element: this.gapsWidgets) {
 			element.reconnectHandlers(this.listener);
 		}


### PR DESCRIPTION
1) Zmiana w handleGradualHideAnswers nie jest piękna, ale nie udało mi się znaleźć lepszego rozwiązania a kończy mi się "zaalokowany" czas. 
2) Poza opisanymi w treści ticketu błędami zauważyłem jeszcze jeden - GSA nie czyści zawartości gap, znikają one dopiero, gdy są zastąpione przez prawidłową odpowiedź. Błąd występuje również na produkcji. Zaproponuję utworzenie dla niego nowego ticketu.

ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/9060--gsa-+-math-gap--b%C5%82%C4%99dne-zachowanie-gap-typu---39-math--39--po-wci/details?comment=1711244004
Wersja testowa: https://test-9060-dot-mauthor-dev.ew.r.appspot.com/
 
