### PR TITLE
Fixed mathjax in Text modules setText method not being rendered correctly, re #9163

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2024-04-15 Fixed mathjax not being rendered when added to a text module via the setText method
 2024-03-22 Fixed draggable gaps with markup in Text weren't receiving correct classes in checkErrorsMode
 2024-03-22 Fixed the conflict between showAllCards vs ShowAllCards in FlashCards
 2024-03-22 Added base width/height properties to the Animation addon

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
@@ -1182,7 +1182,7 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
 		if (commandName.compareTo("settext") == 0 && params.size() > 0) {
 			if (params.size() > 0 && params.get(0) instanceof IStringType) {
 				param = (IStringType) params.get(0);
-				setText(param.getValue());
+				setTextCommand(param.getValue());
 			}
 		} else if (commandName.compareTo("gettext") == 0 && params.size() > 0) {
 			return view.getHTML();
@@ -1418,7 +1418,7 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
 		};
 
 		presenter.setText = function(text) {
-			x.@com.lorepo.icplayer.client.module.text.TextPresenter::setText(Ljava/lang/String;)(text.toString());
+			x.@com.lorepo.icplayer.client.module.text.TextPresenter::setTextCommand(Ljava/lang/String;)(text.toString());
 		};
 
 		presenter.show = function() {
@@ -1682,6 +1682,11 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
 		}
 
 		return true;
+	}
+
+	private void setTextCommand(String text) {
+		setText(text);
+		view.refreshMath();
 	}
 
 	private void setText(String text) {


### PR DESCRIPTION
ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/9163--text--wstawianie-latex-do-modu%C5%82u-za-pomoc%C4%85-settext-oraz-setgaptext/details?comment=1712129873
Wersja testowa: https://test-9163-dot-mauthor-dev.ew.r.appspot.com/present/4866295377952769