### PR TITLE
Fixed magic boxes throwing errors in iceditor on reload, re #LC-9228

### DIFF
--- a/addons/Magic_Boxes/src/presenter.js
+++ b/addons/Magic_Boxes/src/presenter.js
@@ -236,7 +236,7 @@ function AddonMagic_Boxes_create() {
                 presenter.isMouseDown = false;
             });
         }
-        var maxIndex = gridContainer.find(`.${presenter.CSS_CLASSES.ELEMENT_WRAPPER}`).length;
+
         gridContainer.find(`.${presenter.CSS_CLASSES.ELEMENT_WRAPPER}`).each(function() {
             var index = $(this).index();
             var selectedRow = parseInt(index / columns, 10);

--- a/addons/Magic_Boxes/src/presenter.js
+++ b/addons/Magic_Boxes/src/presenter.js
@@ -236,7 +236,7 @@ function AddonMagic_Boxes_create() {
                 presenter.isMouseDown = false;
             });
         }
-
+        var maxIndex = gridContainer.find(`.${presenter.CSS_CLASSES.ELEMENT_WRAPPER}`).length;
         gridContainer.find(`.${presenter.CSS_CLASSES.ELEMENT_WRAPPER}`).each(function() {
             var index = $(this).index();
             var selectedRow = parseInt(index / columns, 10);
@@ -334,6 +334,7 @@ function AddonMagic_Boxes_create() {
     }
 
     function applySelectionStyle(row, column) {
+        if (row >= presenter.configuration.rows || column >= presenter.configuration.columns) return;
         var index = row * presenter.configuration.columns + column;
         var element = gridContainerWrapper.find(`.${presenter.CSS_CLASSES.ELEMENT}:eq(${index})`);
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2924-04-18 Fixed magic boxes throwing errors in iceditor on reload
 2024-04-05 Fixed adding special characters into iframe tag in Paragraph
 2024-04-04 Fixed issue with apostrophes in answers in Text and Table addons
 2024-04-02 Added Send only card changed event property to the FlashCards


### PR DESCRIPTION
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/realtime_cardwall?ticket=9228
Wersja testowa: https://test-9228-dot-mauthor-dev.ew.r.appspot.com/