### PR TITLE
fix(addons): limitedcheck with maintain selected use with gaps and math, re #9336

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2024-06-18 Fixed LimitedCheck with maintain state selected
 2024-06-05 Fixed enabling locked Clock addon
 2024-06-04 Added grading user answer by AI in Paragraph and Paragraph Keyboard
 2024-06-04 Removed inclusion of Open Activities scores for mc

--- a/src/main/java/com/lorepo/icplayer/client/module/limitedcheck/LimitedCheckPresenter.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/limitedcheck/LimitedCheckPresenter.java
@@ -153,15 +153,6 @@ public class LimitedCheckPresenter implements IPresenter, IStateful, ICommandRec
         IJsonServices json = playerServices.getJsonServices();
         HashMap<String, String> decodedState = json.decodeHashMap(state);
 
-        if (decodedState.containsKey("isVisible")) {
-            isVisible = Boolean.parseBoolean(decodedState.get("isVisible"));
-            if (isVisible) {
-                show();
-            } else {
-                hide();
-            }
-        }
-        
         if (model.getMaintainState() && decodedState.containsKey("isShowErrorsMode")) {
         	boolean isShowErrorsMode = Boolean.parseBoolean(decodedState.get("isShowErrorsMode"));
         	if (isShowErrorsMode) {
@@ -171,10 +162,18 @@ public class LimitedCheckPresenter implements IPresenter, IStateful, ICommandRec
         				view.setChecked();
         			}
         		};
-        		t.schedule(0);
+        		t.schedule(250);
         	}
         }
 
+        if (decodedState.containsKey("isVisible")) {
+            isVisible = Boolean.parseBoolean(decodedState.get("isVisible"));
+            if (isVisible) {
+                show();
+            } else {
+                hide();
+            }
+        }
     }
 
     protected void show() {


### PR DESCRIPTION
[ticket](https://app.assembla.com/spaces/lorepo/tickets/9336--bug--math-gaps-+-math-module---problem-przy-maintain-state/details)
[Wersja testowa](https://test-9336-dot-mauthor-dev.ew.r.appspot.com)
[Lekcja](https://test-9336-dot-mauthor-dev.ew.r.appspot.com/present/4825191626571777)