### PR TITLE
Changed contentdataloader to load addons individually by default, re #9364

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2024-07-18 Changed contentDataLoader to download addons individually by default
 2024-07-12 Fixed displaying popups in mobile mCourser
 2024-07-12 Added x and y axis to the Geometric Construct
 2024-07-09 Added Angle figure to the Geometric Construct addon

--- a/src/main/java/com/lorepo/icplayer/client/addonsLoader/LocalAddonsLoader.java
+++ b/src/main/java/com/lorepo/icplayer/client/addonsLoader/LocalAddonsLoader.java
@@ -34,6 +34,8 @@ public class LocalAddonsLoader implements IAddonLoader {
 	private final String ADDONS_DISTRIBUTION_XML = "addons.min.xml";
 	private boolean requestSend = false;
 	private boolean addonsXMLFetched = false;
+	private boolean firstAddonRequestSent = false;
+	private boolean firstAddonXMLFetched = false;
 	private AddonDescriptor currentAddonDescriptor;
 	private HashMap<String, Element> addonsXMLs = new HashMap<String, Element>();
 	private String fetchURL = URLUtils.resolveURL(GWT.getModuleBaseURL() + "build/dist/", ADDONS_DISTRIBUTION_XML);
@@ -44,14 +46,22 @@ public class LocalAddonsLoader implements IAddonLoader {
 
 	@Override
 	public void load(ILoadListener callbacks) {
-		if (this.requestSend) {
-			if(this.addonsXMLFetched) {
-				this.flushAddon(this.currentAddonDescriptor, callbacks);
+		if (this.firstAddonRequestSent) {
+			if (this.firstAddonXMLFetched) {
+				if (this.requestSend) {
+					if(this.addonsXMLFetched) {
+						this.flushAddon(this.currentAddonDescriptor, callbacks);
+					} else {
+						this.addToWaitingQue(this.currentAddonDescriptor, callbacks);
+					}
+				} else {
+					this.loadSingleAddon(this.currentAddonDescriptor, callbacks);
+				}
 			} else {
 				this.addToWaitingQue(this.currentAddonDescriptor, callbacks);
 			}
-		} else {
-			this.requestLoad(callbacks);
+		}else {
+			this.loadFirstAddon(this.currentAddonDescriptor, callbacks);
 		}
 	}
 	
@@ -150,6 +160,48 @@ public class LocalAddonsLoader implements IAddonLoader {
 		for(WaitingDescriptor descriptor : this.queue){
 			descriptor.listener.onError(errorString);
 		}	
+		this.queue.clear();
+	}
+
+	private String getLocalAddonURL(String addonID) {
+		return URLUtils.resolveURL(GWT.getModuleBaseURL() + "addons/",addonID+".xml");
+	}
+
+	private void loadSingleAddon(AddonDescriptor descriptor, ILoadListener callbacks) {
+		String fetchURL = getLocalAddonURL(descriptor.getAddonId());
+		PrivateAddonLoader addonLoader = new PrivateAddonLoader(descriptor, fetchURL);
+		addonLoader.load(callbacks);
+	}
+
+	private void loadFirstAddon(AddonDescriptor descriptor, ILoadListener callbacks) {
+		this.firstAddonRequestSent = true;
+		final LocalAddonsLoader self = this;
+		final ILoadListener finalCallbacks = callbacks;
+		final AddonDescriptor finalDescriptor = descriptor;
+		ILoadListener firstListener = new ILoadListener() {
+			@Override
+			public void onFinishedLoading(Object obj) {
+				self.firstAddonXMLFetched = true;
+				self.loadWaitingAddons();
+				finalCallbacks.onFinishedLoading(obj);
+			}
+
+			@Override
+			public void onError(String error) {
+				JavaScriptUtils.log("Error loading addon: " + finalDescriptor.getAddonId());
+				JavaScriptUtils.log("Fallback: attempt to load addons.min.xml");
+				self.firstAddonXMLFetched = true;
+				self.currentAddonDescriptor = finalDescriptor;
+				self.requestLoad(finalCallbacks);
+			}
+		};
+		this.loadSingleAddon(descriptor, firstListener);
+	}
+
+	private void loadWaitingAddons() {
+		for(WaitingDescriptor descriptor : this.queue){
+			this.loadSingleAddon(descriptor.descriptor, descriptor.listener);
+		}
 		this.queue.clear();
 	}
 }


### PR DESCRIPTION
Ticket: https://learneticsa.assembla.com/spaces/lorepo/tickets/realtime_cardwall?ticket=9364
Wersje testowe
mA: https://test-9364-dot-mauthor-dev.ew.r.appspot.com/
mC: https://test-lc-9364-dd-dot-mcourser-dev.appspot.com/
paczka do mLibro: https://test-9364-dot-mauthor-dev.ew.r.appspot.com/media/icplayer.zip