### PR TITLE
bug(addons): replace domnoderemoved event into mutation observer, re #9391

### DIFF
--- a/addons/Adaptive_Next/src/presenter.js
+++ b/addons/Adaptive_Next/src/presenter.js
@@ -1,5 +1,6 @@
 function AddonAdaptive_Next_create() {
     var presenter = function() {};
+    var observer = null;
 
     presenter.isAdaptivePreviewMode = false;
 
@@ -107,11 +108,11 @@ function AddonAdaptive_Next_create() {
     };
 
     presenter.destroy = function (event) {
-         if (event.target !== this) {
+        if (event.target !== this) {
             return;
         }
+        console.log('destroy AN');
 
-        presenter.view.removeEventListener("DOMNodeRemoved", presenter.destroy);
         presenter.$view.find('.' + presenter.CONSTANTS.ELEMENT_CLASS).off("click", presenter.clickHandler);
     };
 
@@ -132,9 +133,41 @@ function AddonAdaptive_Next_create() {
         presenter.initView();
 
         if (!isPreview) {
+            presenter.createObserver();
+            presenter.setObserver();
             handleMouseActions();
         }
     }
+
+    presenter.createObserver = function () {
+        const _this = this;
+        observer = new MutationObserver(function (records){
+            records.forEach(function (record) {
+                if (record.removedNodes.length) {
+                    presenter.destroy(_this);
+                }
+
+                if (record.target.childNodes.length === 0) {
+                    observer.disconnect();
+                    presenter.setObservedAttr(false);
+                }
+            });
+        });
+    };
+
+    presenter.setObserver = function () {
+        const config = {attributes: true, childList: true};
+        observer.observe($('.ic_page').get(0), config);
+        presenter.setObservedAttr(true);
+    };
+
+    presenter.setObservedAttr = function (value) {
+        $('.ic_page').attr('observed', value);
+    };
+
+    presenter.isObserverSet = function () {
+        return $('.ic_page').attr('observed');
+    };
 
     presenter.setPlayerController = function(controller) {
         presenter.playerController = controller;

--- a/addons/Page_Progress_Panel/src/presenter.js
+++ b/addons/Page_Progress_Panel/src/presenter.js
@@ -1,6 +1,7 @@
 function AddonPage_Progress_Panel_create(){
 
     var presenter = function(){};
+    var observer = null;
 
     presenter.playerController = null;
     presenter.eventBus = null;
@@ -86,15 +87,42 @@ function AddonPage_Progress_Panel_create(){
 			var score = presenter.playerController.getScore().getPageScoreById(pageId);
 			presenter.lastScores.sumOfMaxScore = score.maxScore;
 			presenter.displayScores(presenter.lastScores);
-			presenter.view.addEventListener('DOMNodeRemoved', function onDOMNodeRemoved(event) {
-				if (event.target === this) {
-					presenter.destroy();
-				}
-			});
+            presenter.createObserver();
+            presenter.setObserver();
 			presenter.view.addEventListener('ShowAnswers', this);
 		}
 
     };
+
+    presenter.createObserver = function () {
+        observer = new MutationObserver(function (records){
+            records.forEach(function (record) {
+                if (record.removedNodes.length) {
+                    presenter.destroy();
+                }
+
+                if (record.target.childNodes.length === 0) {
+                    observer.disconnect();
+                    presenter.setObservedAttr(false);
+                }
+            });
+        });
+    };
+
+    presenter.setObserver = function () {
+        const config = {attributes: true, childList: true};
+        observer.observe($('.ic_page').get(0), config);
+        presenter.setObservedAttr(true);
+    };
+
+    presenter.setObservedAttr = function (value) {
+        $('.ic_page').attr('observed', value);
+    };
+
+    presenter.isObserverSet = function () {
+        return $('.ic_page').attr('observed');
+    };
+
 
 	presenter.onEventReceived = function (eventName) {
         if (eventName == "ShowAnswers") {
@@ -111,9 +139,7 @@ function AddonPage_Progress_Panel_create(){
 		presenter.displayScores(presenter.lastScores);
 	};
 
-    presenter.destroy = function (event) {
-        presenter.view.removeEventListener('DOMNodeRemoved', presenter.destroy);
-    };
+    presenter.destroy = function (event) { console.log('destroy PPP')};
 
     function removeHidden(shouldRemove, $element) {
         if (shouldRemove) {


### PR DESCRIPTION
[Ticket](https://app.assembla.com/spaces/lorepo/tickets/9391-zast%C4%85pienie-domnoderemoved-przez-mutationobserver/details)
[Wersja testowa](https://test-9391-dot-mauthor-dev.ew.r.appspot.com)
[Lekcja](https://test-9391-dot-mauthor-dev.ew.r.appspot.com/present/4873943196368897)