### PR TITLE
Fixed bug related to resizing of MathML elements in the Firefox browser, re #PLA-56

### DIFF
--- a/addons/Table/test/GapUtilsTests.js
+++ b/addons/Table/test/GapUtilsTests.js
@@ -374,7 +374,8 @@ TestCase("[Table] [Gap Utils] SetState", {
         };
         this.stubs = {
             connectEvents: sinon.stub(DraggableDroppableObject._internal, 'connectEvents'),
-            validateConfiguration: sinon.stub(DraggableDroppableObject._internal, 'validateConfiguration')
+            validateConfiguration: sinon.stub(DraggableDroppableObject._internal, 'validateConfiguration'),
+            parseAltTexts: sinon.stub()
         };
 
         this.expectedValue = 5;
@@ -387,6 +388,11 @@ TestCase("[Table] [Gap Utils] SetState", {
         this.stubs.setValue = sinon.stub(this.gap, 'setValue');
         this.stubs.setSource = sinon.stub(this.gap, 'setSource');
         this.stubs.setIsEnabled = sinon.stub(this.gap, 'setIsEnabled');
+
+        this.presenter.textParser = {
+            parseAltTexts: this.stubs.parseAltTexts
+        };
+        this.stubs.parseAltTexts.returnsArg(0);
     },
 
     tearDown: function () {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2024-11-26 Fixed bug related to resizing of MathML elements in the Firefox browser
 2024-11-21 Added support to the Magic Boxes addon on interactive whiteboards
 2024-11-19 Added support to the Drawing addon on interactive whiteboards
 2024-11-18 Added support to the Shape Tracing addon on interactive whiteboards

--- a/src/main/java/com/lorepo/icplayer/client/utils/MathJax.java
+++ b/src/main/java/com/lorepo/icplayer/client/utils/MathJax.java
@@ -10,10 +10,10 @@ public class MathJax {
 	 */
 	public static native void refreshMathJax(Element e) /*-{
 		try {
-			// Array is created this way, beacuse in different windows Array prototypes are different objects.
+			// Array is created this way, because in different windows Array prototypes are different objects.
 			// Comparing array variable from one window to Array prototype in different window will return false
             // GWT creates its own window and MathJax is placed in another ($wnd)
-            // This is needed because MathJax compares arguments to instaceof Array
+            // This is needed because MathJax compares arguments to instanceof Array
 			// e.g. (when window !== top):
 			// var array = new Array(); 
 			// array instanceof Array // true
@@ -21,13 +21,35 @@ public class MathJax {
 
 			var args = new $wnd.Array();
 			args.push("Typeset", $wnd.MathJax.Hub, e);
+			if ($wnd.MathJax.Hub.Browser.isFirefox && $wnd.MathJax.Hub.config.jax.includes("output/NativeMML")) {
+				args.push(function(){
+					@com.lorepo.icplayer.client.utils.MathJax::fixMathMLSizeBugOnFirefox(Lcom/google/gwt/dom/client/Element;)(e);
+				});
+			}
 
 			// This adds command to MathJax internal queue and assures all callbacks will be called one after another
-			// Calling MathJax.Callback.Queue() creates a new queue every time, so it shouldn't be used for rerendering purporses 
+			// Calling MathJax.Callback.Queue() creates a new queue every time, so it shouldn't be used for rendering purposes
 			$wnd.MathJax.Hub.Queue(args);
 	  	} catch(err) {
 	  		console.log("Error : " + err);
 		}
+	}-*/;
+
+	private static native void fixMathMLSizeBugOnFirefox(Element element) /*-{
+		// On Firefox <math> element is not rendered correctly. It looks like some CSS styles are not affecting it.	
+		var mathElements = element.getElementsByClassName("MathJax_MathContainer");
+		var mathElementsStyles = [];
+		for (var i = 0; i < mathElements.length; i++) {
+			mathElementsStyles[i] = mathElements[i].style.fontFamily;
+			mathElements[i].style.fontFamily = "STIX TWO MATH";
+		}
+		setTimeout(function (){
+			for (var i = 0; i < mathElementsStyles.length; i++) {
+				try {
+					mathElements[i].style.fontFamily = mathElementsStyles[i];
+				} catch(err) {}
+			}
+		}, 10);
 	}-*/;
 
 	public static native void rerenderMathJax (Element e) /*-{

--- a/src/test/java/com/lorepo_patchers/icplayer/client/utils/MathJaxPatcher.java
+++ b/src/test/java/com/lorepo_patchers/icplayer/client/utils/MathJaxPatcher.java
@@ -9,10 +9,13 @@ import com.lorepo.icplayer.client.utils.MathJaxElement;
 
 @PatchClass(MathJax.class)
 public class MathJaxPatcher {
+	
 	@PatchMethod
 	public static void refreshMathJax(Element e) { }
 	
-	
+	@PatchMethod
+	private static void fixMathMLSizeBug(Element element) { }
+
 	@PatchMethod
 	public static JavaScriptObject setCallbackForMathJaxLoaded(MathJaxElement element) {
 		return JavaScriptObject.createObject();


### PR DESCRIPTION
Ticket: https://learnetic.youtrack.cloud/issue/PLA-56
Test version: https://test-56-dd-dot-mauthor-dev.ew.r.appspot.com
Test lesson: https://test-56-dd-dot-mauthor-dev.ew.r.appspot.com/present/5244806055854081
Icplayer.zip: https://test-56-dd-dot-mauthor-dev.ew.r.appspot.com/media/icplayer.zip

In addition to completing the task, the Table addon tests were also fixed.