### PR TITLE
Fix bug with too small brackets on Safari in MathML equations, re #PLA-74

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2025-01-27 Fixed bug with too small brackets on Safari in MathML equations
 2025-01-17 Fixed misplacing loader
 2025-01-17 Added functionality to automatically add assets from CSS file for paragraph addons
 2025-01-17 Added check to prevent execution of mathJax refresh when player is not ready


### PR DESCRIPTION
Ticket: https://learnetic.youtrack.cloud/issue/PLA-74
Test version: https://test-pla-74-dd-dot-mauthor-dev.ew.r.appspot.com
Test lesson: https://test-pla-74-dd-dot-mauthor-dev.ew.r.appspot.com/present/3075461496657097

Lack of tests is due to inability to create tests for native methods