### PR TITLE
Fixed parentheses with integrals having incorrect size, re #PLA-73

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2025-01-27 Fixed Math parentheses having incorrect size if they contain integrals 
 2025-01-09 Added support in Coloring and Shape Tracing addons to crossorigin files if domain is on whitelist
 2024-12-23 Added Addons_Loaded event sending when addons are loaded
 2024-12-20 Fixed issues with m3u8 in video on ios devices

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextParser.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextParser.java
@@ -119,6 +119,7 @@ public class TextParser {
 				parserResult.parsedText = parseAltText(parserResult.parsedText);
 				parserResult.parsedText = parseDefinitions(parserResult.parsedText);
 				parserResult.parsedText = parseAddonGap(parserResult.parsedText, false);
+				parserResult.parsedText = parseMathParentheses(parserResult.parsedText);
 			}
 		} catch (Exception e) {
 			parserResult.parsedText = "#ERROR#";
@@ -183,6 +184,7 @@ public class TextParser {
 		result.parsedText = parseDefinitions(result.parsedText);
 		result.parsedText = parseAudio(result.parsedText);
 		result.parsedText = parseAddonGap(result.parsedText, true);
+		result.parsedText = parseMathParentheses(result.parsedText);
 
 		result.hasSyntaxError = hasSyntaxError;
 		return result;
@@ -683,6 +685,17 @@ public class TextParser {
 				break;
 			}
 		}
+		return parsedText;
+	}
+
+	private String parseMathParentheses(String srcText) {
+        // MathJax 2.7.9 will occasionally incorrectly calculate the size of parentheses
+        // Such as when a nested parentheses contains integrals and gaps.
+        String parsedText = srcText;
+        if (useMathGaps && srcText.indexOf("\\int_{") > -1) {
+            parsedText = parsedText.replaceAll("\\\\left\\(", "\\\\left\\({");
+            parsedText = parsedText.replaceAll("\\\\right\\)", "}\\\\right\\)");
+        }
 		return parsedText;
 	}
 	

--- a/src/test/java/com/lorepo/icplayer/client/module/text/GWTTextParserTestCase.java
+++ b/src/test/java/com/lorepo/icplayer/client/module/text/GWTTextParserTestCase.java
@@ -463,4 +463,18 @@ public class GWTTextParserTestCase extends GwtTest{
 		assertEquals(expected, parsed.parsedText);
 
 	}
+
+	@Test
+	public void testGivenMathIntegralInsideParenthesesWhenParseIsCalledThenAddCurlyBracesToEnsureCorrectParenthesesHeight() {
+
+		TextParser parser = new TextParser();
+		String srcText ="\\(\\left(\\int_{X}dx\\right)\\)";
+		String expected = "\\(\\left({\\int_{X}dx}\\right)\\)";
+
+		parser.setId("xcf");
+		parser.setUseMathGaps(true);
+		ParserResult parsed = parser.parse(srcText);
+
+		assertEquals(expected, parsed.parsedText);
+	}
 }


### PR DESCRIPTION
ticket: https://learnetic.youtrack.cloud/issue/PLA-73/MathJax-2.7-Problem-z-zagniezdzonymi-nawiasami
wersja testowa: https://test-pla-73-dot-mauthor-dev.ew.r.appspot.com/present/7770929026166925

Błąd jest reprodukowalny na Firefox