### PR TITLE
Fixed double equations sometimes occuring when mathjax 2.7 is enabled re #PLA-96

### DIFF
--- a/addons/Double_State_Button/src/presenter.js
+++ b/addons/Double_State_Button/src/presenter.js
@@ -557,7 +557,9 @@ function AddonDouble_State_Button_create(){
     presenter.updateLaTeX = function () {
         var textElement = presenter.$view.find('.doublestate-button-text')[0];
         presenter.mathJaxProcessEnded.then(function () {
-                MathJax.CallBack.Queue().Push(function () {MathJax.Hub.Typeset(textElement)});
+                const args = [];
+                args.push("Typeset", MathJax.Hub, textElement);
+                MathJax.Hub.Queue(args);
         });
     };
 

--- a/addons/FlashCards/src/presenter.js
+++ b/addons/FlashCards/src/presenter.js
@@ -1108,9 +1108,9 @@ function AddonFlashCards_create(){
     }
 
     function reloadMathJax () {
-        window.MathJax.Callback.Queue().Push(function () {
-            window.MathJax.Hub.Typeset(presenter.$view[0]);
-        });
+        const args = [];
+        args.push("Typeset", MathJax.Hub, presenter.$view[0]);
+        MathJax.Hub.Queue(args);
     }
 
     function parseAltText(text) {

--- a/addons/Math/src/presenter.js
+++ b/addons/Math/src/presenter.js
@@ -701,9 +701,9 @@ function AddonMath_create() {
     }
 
     presenter.reloadMathJax = function() {
-        MathJax.CallBack.Queue().Push(function () {
-            MathJax.Hub.Typeset();
-        });
+        const args = [];
+        args.push("Typeset", MathJax.Hub);
+        MathJax.Hub.Queue(args);
     }
 
     presenter.moduleAnswersCounter = function (module) {

--- a/addons/Quiz/src/presenter.js
+++ b/addons/Quiz/src/presenter.js
@@ -662,9 +662,9 @@ function AddonQuiz_create() {
     }
 
     function reloadMathJax() {
-        window.MathJax.Callback.Queue().Push(function () {
-            window.MathJax.Hub.Typeset(presenter.$view[0]);
-        });
+        const args = [];
+        args.push("Typeset", MathJax.Hub, presenter.$view[0]);
+        MathJax.Hub.Queue(args);
     }
 
     presenter.setPlayerController = function AddonQuiz_setPlayerController(controller) {

--- a/addons/Table/src/presenter.js
+++ b/addons/Table/src/presenter.js
@@ -2112,17 +2112,17 @@ function AddonTable_create() {
     };
 
     presenter.renderMathJax = function () {
-        MathJax.CallBack.Queue().Push(function () {
-            MathJax.Hub.Typeset(presenter.$view.find(".table-addon-wrapper")[0]);
-        });
+        const args = [];
+        args.push("Typeset", MathJax.Hub, presenter.$view.find(".table-addon-wrapper")[0]);
+        MathJax.Hub.Queue(args);
 
         addDisplayStyleToMathJaxElements();
     };
 
     presenter.rerenderMathJax = function () {
-        MathJax.CallBack.Queue().Push(function () {
-            MathJax.Hub.Rerender(presenter.$view.find(".table-addon-wrapper")[0]);
-        });
+        const args = [];
+        args.push("Rerender", MathJax.Hub, presenter.$view.find(".table-addon-wrapper")[0]);
+        MathJax.Hub.Queue(args);
 
         addDisplayStyleToMathJaxElements();
     };

--- a/addons/gamememo/src/presenter.js
+++ b/addons/gamememo/src/presenter.js
@@ -1521,7 +1521,9 @@ function Addongamememo_create(){
         presenter.createGrid();
         presenter.concealAllCards();
 
-        MathJax.CallBack.Queue().Push(function () {MathJax.Hub.Typeset(presenter.viewContainer.find(".gamememo_container")[0])});
+        const args = [];
+        args.push("Typeset", MathJax.Hub, presenter.viewContainer.find(".gamememo_container")[0]);
+        MathJax.Hub.Queue(args);
 
         presenter.configuration.isVisible = presenter.configuration.isVisibleByDefault;
         presenter.setVisibility(presenter.configuration.isVisibleByDefault);

--- a/addons/multiplegap/src/presenter.js
+++ b/addons/multiplegap/src/presenter.js
@@ -537,9 +537,9 @@ function Addonmultiplegap_create(){
     };
 
     presenter.updateLaTeX = function (element) {
-        MathJax.Hub.Queue(() => {
-            MathJax.Hub.Typeset(element)
-        });
+        const args = [];
+        args.push("Typeset", MathJax.Hub, element);
+        MathJax.Hub.Queue(args);
     };
 
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2025-02-21 Fixed double equations sometimes occuring when mathjax 2.7 is enabled
 2025-02-14 Fixed setPrintableOrder malfunction in mCourser
 2025-02-14 Fixed issue with hls files in the video addon when a page is reloaded
 2025-02-12 Fixed problem with missing library for video addon


### PR DESCRIPTION
Ticket: https://learnetic.youtrack.cloud/issue/PLA-96/MathML-Podwojne-generowanie-wzorow
Wersja testowa (mathjax 2.7): https://test-pla-96-dot-mauthor-dev.ew.r.appspot.com/present/1650051435929215
Wersja testowa (mathjax 2.1): https://test-pla-96-21-dot-mauthor-dev.ew.r.appspot.com/present/1650051435929215