### PR TITLE
Fixed issue with escaped html characters inside alt text in draggable Text gaps, re #PLA-157

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2025-04-02 Fixed issue with escaped html characters inside alt text in draggable Text gaps
 2025-03-21 Fixed issue with < inside MathJax brackets  in Math addon
 2025-03-18 Added initJSObject method to CheckCounter module
 2025-03-18 Added auto 'Table cells' list expansion/reduction in Table addon

--- a/src/main/java/com/lorepo/icplayer/client/model/alternativeText/AlternativeTextService.java
+++ b/src/main/java/com/lorepo/icplayer/client/model/alternativeText/AlternativeTextService.java
@@ -100,7 +100,7 @@ public class AlternativeTextService {
                 String visible = token.getVisibleText();
                 String readable = token.getReadableText();
                 String escapedText = AlternativeTextTemplates.TEMPLATES.altTextEscaped(visible, readable).asString();
-
+                escapedText = unescapeHTML(escapedText);
                 builder.append(escapedText);
 
                 if (token.getLanguage() != null) {
@@ -113,6 +113,13 @@ public class AlternativeTextService {
 
         return builder.toString();
     }
+
+    private static String unescapeHTML(String sourceText) {
+        String escapedText = sourceText.replaceAll("&lt;", "<");
+        escapedText = escapedText.replaceAll("&gt;", ">");
+        escapedText = escapedText.replaceAll("&amp;", "&");
+        return escapedText;
+    };
 
     public static String unescapeAltText(String srcText) {
         return unescapeAltText(srcText, false);

--- a/src/test/java/com/lorepo/icplayer/client/model/AltText/GWTAltTextEscapingTestCase.java
+++ b/src/test/java/com/lorepo/icplayer/client/model/AltText/GWTAltTextEscapingTestCase.java
@@ -128,4 +128,14 @@ public class GWTAltTextEscapingTestCase extends GwtTest {
         assertEquals(expected, output);
     }
 
+    @Test
+    public void givenTextAndAltTextWithEscapedHTMLCharacterAsPartOfVisibleTextWhenUnEscapingAllVisibleAltTextThenReturnsUnEscapedText() {
+        String input = "additionalText \\alt{visibleText&amp;|readableText} additionalText";
+        String expected = "additionalText \\altEscapedvisibleText&amp;&altTextSeperator&readableText&altTextEnd& additionalText";
+
+        String output = AlternativeTextService.escapeAltTextWithAllVisibleText(input);
+
+        assertEquals(expected, output);
+    }
+
 }


### PR DESCRIPTION
ticket: https://learnetic.youtrack.cloud/issue/PLA-157/BUG-Blad-Source-list-alt-text
wersja testowa: https://test-pla-157-dot-mauthor-dev.ew.r.appspot.com/present/4808442780844033