### PR TITLE
Fixed media recorder analyzer being blocked on Safari

### DIFF
--- a/addons/Media_Recorder/src/presenter.js
+++ b/addons/Media_Recorder/src/presenter.js
@@ -1300,11 +1300,6 @@ var MediaRecorder = exports.MediaRecorder = function () {
             var upgradedModel = this._upgradeModel(model);
             var validatedModel = (0, _validateModel.validateModel)(upgradedModel);
 
-            var isSafari = DevicesUtils.getBrowserVersion().toLowerCase().indexOf("safari") > -1;
-            if (isSafari) {
-                this.enableAnalyser = false;
-            }
-
             if (this._isBrowserNotSupported()) {
                 this._showBrowserError(view);
             } else if (validatedModel.isValid) {

--- a/addons/Media_Recorder/src_webpack/MediaRecorder.jsm
+++ b/addons/Media_Recorder/src_webpack/MediaRecorder.jsm
@@ -39,11 +39,6 @@ export class MediaRecorder {
         let upgradedModel = this._upgradeModel(model);
         let validatedModel = validateModel(upgradedModel);
 
-        const isSafari = DevicesUtils.getBrowserVersion().toLowerCase().indexOf("safari") > -1;
-        if (isSafari) {
-            this.enableAnalyser = false;
-        }
-
         if (this._isBrowserNotSupported()) {
             this._showBrowserError(view)
         } else if (validatedModel.isValid) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2025-09-29 Fixed media recorder analyzer being blocked on Safari
 2025-09-19 Fixed rendering of content with alt texts and MathJax in print
 2025-09-19 Changed events in MathText addon
 2025-09-08 Added command to disable usage of state in printable functionality


### PR DESCRIPTION
ticket: https://learnetic.youtrack.cloud/issue/PLA-222/Nie-dzialajacy-analizator-w-MediaRecorder-dla-Safari
Wersja testowa: https://test-pla-222-dot-mauthor-dev.ew.r.appspot.com/present/7685840444411144