### PR TITLE
Fixed nested addons getting overwritten in Text on getState, re #PLA-219

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2025-10-02 Fixed issue with nested addons getting overwritten in the Text module on getState
 2025-09-23 Fixed loading icon not being centered correctly on mobile mCourser
 2025-09-19 Fixed rendering of content with alt texts and MathJax in print
 2025-09-19 Changed events in MathText addon

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
@@ -105,6 +105,7 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
 		void enableDraggableGapExtension(String gapId);
 		void disableDraggableGapExtension(String gapId);
 		void addIOSClass();
+		boolean hasAddonGaps();
 	}
 
 	public interface NavigationTextElement {
@@ -512,7 +513,7 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
 
 		savedDisabledState = stateDisabled;
 
-		if (module.hasMathGaps() && !isShowAnswersActive) {
+		if (module.hasMathGaps() && !isShowAnswersActive && !view.hasAddonGaps()) {
 			view.setHTML(module.parsedText);
 			view.refreshMath();
 			((TextView) view).reconnectHandlers();

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
@@ -1268,8 +1268,6 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 	}
 
 	private native boolean hasAddonGaps(Element x)/*-{
-	    console.log("hasAddonGaps");
-	    console.log($wnd.$(x).find('.inner_addon').length > 0);
 	    return $wnd.$(x).find('.inner_addon').length > 0;
 	}-*/;
 

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
@@ -1262,4 +1262,15 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 		return scores;
 	}
 
+    @Override
+	public boolean hasAddonGaps() {
+	    return hasAddonGaps(this.getElement());
+	}
+
+	private native boolean hasAddonGaps(Element x)/*-{
+	    console.log("hasAddonGaps");
+	    console.log($wnd.$(x).find('.inner_addon').length > 0);
+	    return $wnd.$(x).find('.inner_addon').length > 0;
+	}-*/;
+
 }

--- a/src/test/java/com/lorepo/icplayer/client/module/text/mockup/TextViewMockup.java
+++ b/src/test/java/com/lorepo/icplayer/client/module/text/mockup/TextViewMockup.java
@@ -235,4 +235,9 @@ public class TextViewMockup implements IDisplay {
 
 	@Override
 	public void addIOSClass() {}
+
+	@Override
+	public boolean hasAddonGaps() {
+	    return false;
+    }
 }


### PR DESCRIPTION
ticket: https://learnetic.youtrack.cloud/issue/PLA-219/inneraddon-ponowne-wejscie-na-strone-niszczy-inneraddon
wersja testowa: https://test-pla-219-dot-mauthor-dev.ew.r.appspot.com/present/7766713510220833