### PR TITLE
Fixed issue with audioplaylist duration on ipad, re #PLA-239

### DIFF
--- a/addons/AudioPlaylist/src/presenter.js
+++ b/addons/AudioPlaylist/src/presenter.js
@@ -1086,6 +1086,7 @@ function AddonAudioPlaylist_create() {
 
         name.innerText = item.name;
         time.innerText = "00:00";
+        time.classList.add("timeElement");
 
         playButton.addEventListener("click", AddonAudioPlaylistItemWrapper__buttonHandler.bind(this));
         playButton.addEventListener("touch", AddonAudioPlaylistItemWrapper__buttonHandler.bind(this));
@@ -1100,9 +1101,13 @@ function AddonAudioPlaylist_create() {
     }
 
      function AddonAudioPlaylistItemWrapper__audioDurationChange(ev) {
-        this.time.innerText = StringUtils.timeFormat(isNaN(this.audio.duration) ? 0 : this.audio.duration);
-        this.audio.removeEventListener("durationchange", AddonAudioPlaylistItemWrapper__audioDurationChange);
-        this.audio = null;
+        if (!this || !this.time || !this.audio) return;
+        let self = this;
+        setTimeout(()=> {
+            self.time.innerText = StringUtils.timeFormat(isNaN(self.audio.duration) ? 0 : self.audio.duration);
+            self.audio.removeEventListener("durationchange", AddonAudioPlaylistItemWrapper__audioDurationChange);
+            self.audio = null;
+        }, 0);
     }
 
     function AddonAudioPlaylistItemWrapper__buttonHandler(ev) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2026-01-21 Fixed issue with audio playlist duration on ipad
 2026-01-15 Fixed alt text not working in True False choices
 2026-01-14 Fixed issue with gaps inside both alt text and latex in Table addon
 2026-01-09 Added labels property to Lesson Progress


### PR DESCRIPTION
ticket: https://learnetic.youtrack.cloud/issue/PLA-239/Nie-poprawnie-dzialajace-audio-w-playliscie-iPad
wersja testowa: https://test-pla-239-dot-mauthor-dev.ew.r.appspot.com/
paczka: https://test-pla-239-dot-mauthor-dev.ew.r.appspot.com/media/icplayer.zip