### PR TITLE
Fixed centering of reset button popup when there is empty space left of the content, re #PLA-141

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2026-01-29 Fixed centering of reset button popup when there is empty space left of the content
 2026-01-15 Fixed alt text not working in True False choices
 2026-01-14 Fixed issue with gaps inside both alt text and latex in Table addon
 2026-01-09 Added labels property to Lesson Progress

--- a/src/main/java/com/lorepo/icplayer/client/module/button/ResetButton.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/button/ResetButton.java
@@ -66,6 +66,16 @@ class ResetButton extends ExecutableButton {
 		});
 	}
 
+	private static native int calculateTopWhenCentred(Element popupElement) /*-{
+		var elementHeight = popupElement.getBoundingClientRect().height;
+		return $wnd.PositioningUtils.calculateTopForPopupToBeCentred(elementHeight);
+	}-*/;
+
+	private static native int calculateLeftWhenCentred(Element popupElement) /*-{
+		var elementWidth = popupElement.getBoundingClientRect().width;
+		return $wnd.PositioningUtils.calculateLeftForPopupToBeCentred(elementWidth);
+	}-*/;
+
 	public void execute(){
 		if(this.confReset){
 
@@ -98,8 +108,6 @@ class ResetButton extends ExecutableButton {
 	        dialogHPanel.add(noButton);
 	        this.element = getElement();
 	        parent = this.element.getParentElement();
-	        int top = 200 + Window.getScrollTop();
-	        int left = (parent.getClientWidth() / 2) - 150;
 
 	        noButton.addClickHandler(new ClickHandler() {
 	            @Override
@@ -126,8 +134,11 @@ class ResetButton extends ExecutableButton {
 			buttons.add(noButton);
 
             dialogBox.setWidget(dialogHPanel);
-            dialogBox.setPopupPosition(left, top);
             dialogBox.show();
+
+            int top = calculateTopWhenCentred(dialogBox.getElement());
+	        int left = calculateLeftWhenCentred(dialogBox.getElement());
+            dialogBox.setPopupPosition(left, top);
         } else {
             this.pageService.reset(resetOnlyWrong);
         }


### PR DESCRIPTION
Ticket: https://learnetic.youtrack.cloud/issue/PLA-141/Support-Nieprawidlowa-pozycja-okna-confirm-box
Wersja testowa mA: https://test-pla-141-dot-mauthor-dev.ew.r.appspot.com/
Wersja testowa mC: https://test-mc-pla-141-dot-mcourser-dev.appspot.com/