### PR TITLE
Fixed position display in shape tracing editor, re #PLA-271

### DIFF
--- a/addons/Shape_Tracing/src/presenter.js
+++ b/addons/Shape_Tracing/src/presenter.js
@@ -379,13 +379,13 @@ function AddonShape_Tracing_create() {
         });
         presenter.text = new Kinetic.Text({
             x: position, y: position,
-            text: prepearText(0, 0),
+            text: prepareText(0, 0),
             fontSize: 15,
             fontFamily: 'Calibri',
             fill: '#555',
             width: box_width,
             padding: 4,
-            align: 'center'
+            align: 'left'
         });
 
         presenter.layerBG.add(presenter.box);
@@ -393,17 +393,8 @@ function AddonShape_Tracing_create() {
         presenter.stageBG.add(presenter.layerBG);
     }
 
-    function prepearText(x, y) {
-        function addZerosToNumber(n) {
-            switch (n.toString().length) {
-                case 1: return "000" + n;
-                case 2: return "00" + n;
-                case 3: return "0" + n;
-                default: return "" + n;
-            }
-        }
-
-        return "X:" + addZerosToNumber(Math.round(x)) + "\nY:" + addZerosToNumber(Math.round(y));
+    function prepareText(x, y) {
+        return "X:" + Math.round(x) + "\nY:" + Math.round(y);
     }
 
     function cursorCoordinates() {
@@ -419,7 +410,7 @@ function AddonShape_Tracing_create() {
                     moduleSelector.releasePointerCapture(event.pointerId);
                 }
 
-                presenter.text.setText(prepearText(event.offsetX, event.offsetY));
+                presenter.text.setText(prepareText(event.offsetX, event.offsetY));
                 presenter.layerBG.draw();
             }, false);
         });
@@ -434,7 +425,7 @@ function AddonShape_Tracing_create() {
             }
             event.stopPropagation();
 
-            presenter.text.setText(prepearText(event.offsetX, event.offsetY));
+            presenter.text.setText(prepareText(event.offsetX, event.offsetY));
             presenter.layerBG.draw();
         }, false);
     }

--- a/addons/Shape_Tracing/src/presenter.js
+++ b/addons/Shape_Tracing/src/presenter.js
@@ -403,11 +403,11 @@ function AddonShape_Tracing_create() {
             }
         }
 
-        return "X:" + addZerosToNumber(x) + "\nY:" + addZerosToNumber(y);
+        return "X:" + addZerosToNumber(Math.round(x)) + "\nY:" + addZerosToNumber(Math.round(y));
     }
 
     function cursorCoordinates() {
-        drawBoxPointerData(52, 37);
+        drawBoxPointerData(53, 37);
 
         presenter.data.shapeImageLoaded.then(function() {
             const moduleSelector = $(`.moduleSelector[data-id="${presenter.configuration.ID}"]`)[0];

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2026-03-13 Fixed position display in shape tracing editor
 2026-02-25 Fixed wrong max score's calculation in FigureDrawing
 2026-02-02 Fixed needless tts reseting on Chrome
 2026-01-29 Fixed centering of reset button popup when there is empty space left of the content


### PR DESCRIPTION
Ticket: https://learnetic.youtrack.cloud/issue/PLA-271/Modul-Shape-Tracing-pokazuje-miejsca-po-przecinku-podczas-edycji-punktow
Wersja testowa: https://test-pla-271-dot-mauthor-dev.ew.r.appspot.com/