### PR TITLE
Fix scroll event handlers in Text module not being removed after lesson's page change, re #PLA-280

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2026-05-11 Fixed scroll event handlers in Text module not being removed after lesson's page change
 2026-05-07 Added support for Alternative Texts in the Text Coloring
 2026-04-13 Added support for MathJax in EditableWindow
 2026-03-18 Fixed problem with nested LaTeX syntax in Text Coloring

--- a/src/main/java/com/lorepo/icplayer/client/PlayerController.java
+++ b/src/main/java/com/lorepo/icplayer/client/PlayerController.java
@@ -684,7 +684,7 @@ public class PlayerController implements IPlayerController {
 	@Override
 	public int getIframeScroll() {
 		// when true, iframeScroll set by parsing message
-		if (isIframeInCrossDomain && !$wnd.window.top) {
+		if (isIframeInCrossDomain || !$wnd.window.top) {
 			return this.iframeScroll;
 		}
 		return this.getScrollTop();

--- a/src/main/java/com/lorepo/icplayer/client/PlayerController.java
+++ b/src/main/java/com/lorepo/icplayer/client/PlayerController.java
@@ -684,7 +684,7 @@ public class PlayerController implements IPlayerController {
 	@Override
 	public int getIframeScroll() {
 		// when true, iframeScroll set by parsing message
-		if (isIframeInCrossDomain) {
+		if (isIframeInCrossDomain && !$wnd.window.top) {
 			return this.iframeScroll;
 		}
 		return this.getScrollTop();

--- a/src/main/java/com/lorepo/icplayer/client/PlayerController.java
+++ b/src/main/java/com/lorepo/icplayer/client/PlayerController.java
@@ -684,13 +684,16 @@ public class PlayerController implements IPlayerController {
 	@Override
 	public int getIframeScroll() {
 		// when true, iframeScroll set by parsing message
-		if (isIframeInCrossDomain || !$wnd.window.top) {
+		if (isIframeInCrossDomain) {
 			return this.iframeScroll;
 		}
-		return this.getScrollTop();
+		return this.getScrollTop(this);
 	}
 	
-	private native int getScrollTop() /*-{
+	private native int getScrollTop(PlayerController x) /*-{
+		if (!$wnd.window.top) {
+		    return x.@com.lorepo.icplayer.client.PlayerController::iframeScroll;
+		}
 		var scrollTop = $wnd.window.top.pageYOffset;
 		if (scrollTop === 0) {
 			var contentView = $wnd.document.getElementById('content-view');

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
@@ -94,9 +94,9 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
 		void connectMathGap(Iterator<GapInfo> giIterator, String id, ArrayList<Boolean> savedDisabledState);
 		HashMap<String, String> getDroppedElements();
 		void setDroppedElements(String id, String element);
-		void connectDOMNodeRemovedEvent(String id, String scrollNamespace);
+		void connectDOMNodeRemovedEvent(String id, String scrollNamespace, boolean isCrossDomain);
 		JavaScriptObject findScrollElements(boolean isCrossDomain);
-		void removeScrollHandlers(String scrollNamespace);
+		void removeScrollHandlers(String scrollNamespace, boolean isCrossDomain);
 		void sortGapsOrder();
 		boolean isWCAGon();
 		void setWorkMode();
@@ -804,7 +804,7 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
 			}
 		}
 
-		view.connectDOMNodeRemovedEvent(module.getId(), scrollNamespace);
+		view.connectDOMNodeRemovedEvent(module.getId(), scrollNamespace, isPlayerInCrossDomain());
 		addiOSClassWithTimeout(this);
 	}
 
@@ -2073,7 +2073,7 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
 	private void preDestroy(){
 		sendTimerEvent();
 		if (view != null && scrollNamespace != null) {
-			view.removeScrollHandlers(scrollNamespace);
+			view.removeScrollHandlers(scrollNamespace, isPlayerInCrossDomain());
 		}
 	}
 

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
@@ -2041,10 +2041,14 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
         return false;
 	}
 
+	private JavaScriptObject findScrollElements (boolean isCrossDomain) {
+        return view.findScrollElements(isCrossDomain);
+    }
+
 	private native void setupScrollHandlers (TextPresenter x, Element e, String namespace) /*-{
 		var eventName = 'scroll.' + namespace;
 		var isCrossDomain = x.@com.lorepo.icplayer.client.module.text.TextPresenter::isPlayerInCrossDomain()();
-		var scrollElements = x.@com.lorepo.icplayer.client.module.text.TextPresenter::view.findScrollElements(Z)(isCrossDomain);
+		var scrollElements = x.@com.lorepo.icplayer.client.module.text.TextPresenter::findScrollElements(Z)(isCrossDomain);
 		try {
 			for (var i = 0; i < scrollElements.length; i++) {
 				if (scrollElements[i] && scrollElements[i].length) {

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
@@ -94,7 +94,9 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
 		void connectMathGap(Iterator<GapInfo> giIterator, String id, ArrayList<Boolean> savedDisabledState);
 		HashMap<String, String> getDroppedElements();
 		void setDroppedElements(String id, String element);
-		void connectDOMNodeRemovedEvent(String id);
+		void connectDOMNodeRemovedEvent(String id, String scrollNamespace);
+		JavaScriptObject findScrollElements(boolean isCrossDomain);
+		void removeScrollHandlers(String scrollNamespace);
 		void sortGapsOrder();
 		boolean isWCAGon();
 		void setWorkMode();
@@ -142,6 +144,7 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
 	private boolean isGradualShowAnswers = false;
 	private Date startTime = null;
 	private long timerBase = 0;
+	private String scrollNamespace = null;
 
 	public TextPresenter(TextModel module, IPlayerServices services) {
 		this.module = module;
@@ -788,7 +791,9 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
 			view = (IDisplay) display;
 			connectViewListener();
 			updateViewText();
-			setupScrollHandlers(this, view.getElement());
+			this.scrollNamespace = getPageStamp() + "_" + module.getId();
+			JavaScriptObject scrollElements = view.findScrollElements(isPlayerInCrossDomain());
+			setupScrollHandlers(scrollElements, view.getElement(), this, this.scrollNamespace);
 			if (isVisibleInViewport()) startTimer();
 		}
 
@@ -799,7 +804,7 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
 			}
 		}
 
-		view.connectDOMNodeRemovedEvent(module.getId());
+		view.connectDOMNodeRemovedEvent(module.getId(), scrollNamespace);
 		addiOSClassWithTimeout(this);
 	}
 
@@ -2037,27 +2042,12 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
         return false;
 	}
 
-	private native JavaScriptObject findScrollElements(boolean isCrossDomain)/*-{
-		var $defaultScrollElement = isCrossDomain ? null : $wnd.$($wnd.parent.document);
-		var $mCourserScrollElement = isCrossDomain ? null : $defaultScrollElement.find('#lesson-view > div > div');
-		var $mAuthorMobileScrollElement = $wnd.$($wnd);
-		var $mCourserMobileScrollElement = $wnd.$("#content-view");
-		var $mLibroDesktopScrollElement = null;
-		var icplayerContent = $wnd.$("#_icplayerContent");
-		if (icplayerContent.length > 0) $mLibroDesktopScrollElement = $wnd.$(icplayerContent[0].shadowRoot.querySelector(".inner-scroll"));
-		return [
-			$defaultScrollElement, $mCourserScrollElement, $mAuthorMobileScrollElement,
-			$mCourserMobileScrollElement, $mLibroDesktopScrollElement
-		];
-	}-*/;
-
-	private native void setupScrollHandlers (TextPresenter x, Element e) /*-{
-	    var isCrossDomain = x.@com.lorepo.icplayer.client.module.text.TextPresenter::isPlayerInCrossDomain()();
-		var scrollElements = x.@com.lorepo.icplayer.client.module.text.TextPresenter::findScrollElements(Z)(isCrossDomain);
+	private native void setupScrollHandlers (JavaScriptObject scrollElements, Element e, TextPresenter x, String namespace) /*-{
+		var eventName = 'scroll.' + namespace;
 		try {
 			for (var i = 0; i < scrollElements.length; i++) {
 				if (scrollElements[i] && scrollElements[i].length) {
-					scrollElements[i].scroll(function(){
+					scrollElements[i].on(eventName, function(){
 						if ($wnd.$(e).parent().length == 0) return;
 						var visible = x.@com.lorepo.icplayer.client.module.text.TextPresenter::isVisibleInViewport()();
 						if (visible) {
@@ -2082,6 +2072,9 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
 
 	private void preDestroy(){
 		sendTimerEvent();
+		if (view != null && scrollNamespace != null) {
+			view.removeScrollHandlers(scrollNamespace);
+		}
 	}
 
 }

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
@@ -2050,6 +2050,9 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
 				if (scrollElements[i] && scrollElements[i].length) {
 					scrollElements[i].on(eventName, function(){
 						if ($wnd.$(e).parent().length == 0) return;
+						if (!isCrossDomain && !$wnd.window.top) {
+						    return;
+                        }
 						var visible = x.@com.lorepo.icplayer.client.module.text.TextPresenter::isVisibleInViewport()();
 						if (visible) {
 							x.@com.lorepo.icplayer.client.module.text.TextPresenter::startTimer()();

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextPresenter.java
@@ -792,8 +792,7 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
 			connectViewListener();
 			updateViewText();
 			this.scrollNamespace = getPageStamp() + "_" + module.getId();
-			JavaScriptObject scrollElements = view.findScrollElements(isPlayerInCrossDomain());
-			setupScrollHandlers(scrollElements, view.getElement(), this, this.scrollNamespace);
+			setupScrollHandlers(this, view.getElement(), this.scrollNamespace);
 			if (isVisibleInViewport()) startTimer();
 		}
 
@@ -2042,8 +2041,10 @@ public class TextPresenter implements IPresenter, IStateful, IActivity, ICommand
         return false;
 	}
 
-	private native void setupScrollHandlers (JavaScriptObject scrollElements, Element e, TextPresenter x, String namespace) /*-{
+	private native void setupScrollHandlers (TextPresenter x, Element e, String namespace) /*-{
 		var eventName = 'scroll.' + namespace;
+		var isCrossDomain = x.@com.lorepo.icplayer.client.module.text.TextPresenter::isPlayerInCrossDomain()();
+		var scrollElements = x.@com.lorepo.icplayer.client.module.text.TextPresenter::view.findScrollElements(Z)(isCrossDomain);
 		try {
 			for (var i = 0; i < scrollElements.length; i++) {
 				if (scrollElements[i] && scrollElements[i].length) {

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
@@ -697,7 +697,36 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 		}
 	}
 
-	public native void connectDOMNodeRemovedEvent (String id) /*-{
+	public native JavaScriptObject findScrollElements (boolean isCrossDomain) /*-{
+		var $defaultScrollElement = isCrossDomain ? null : $wnd.$($wnd.parent.document);
+		var $mCourserScrollElement = isCrossDomain ? null : $defaultScrollElement.find('#lesson-view > div > div');
+		var $mAuthorMobileScrollElement = $wnd.$($wnd);
+		var $mCourserMobileScrollElement = $wnd.$("#content-view");
+		var $mLibroDesktopScrollElement = null;
+		var icplayerContent = $wnd.$("#_icplayerContent");
+		if (icplayerContent.length > 0) $mLibroDesktopScrollElement = $wnd.$(icplayerContent[0].shadowRoot.querySelector(".inner-scroll"));
+		return [
+			$defaultScrollElement, $mCourserScrollElement, $mAuthorMobileScrollElement,
+			$mCourserMobileScrollElement, $mLibroDesktopScrollElement
+		];
+	}-*/;
+
+	public native void removeScrollHandlers (String scrollNamespace) /*-{
+		console.log("Execute removeScrollHandlers: " + scrollNamespace);
+		var isCrossDomain = $wnd.self !== $wnd.parent;
+		var scrollElements = this.@com.lorepo.icplayer.client.module.text.TextView::findScrollElements(Z)(isCrossDomain);
+		var eventName = 'scroll.' + scrollNamespace;
+		try {
+			for (var i = 0; i < scrollElements.length; i++) {
+				if (scrollElements[i] && scrollElements[i].length) {
+					scrollElements[i].off(eventName);
+				}
+			}
+		} catch (err) {}
+	}-*/;
+
+	public native void connectDOMNodeRemovedEvent (String id, String scrollNamespace) /*-{
+		var self = this;
 		var $addon = $wnd.$(".ic_page [id='" + id + "']"),
 			addon = $addon[0];
 
@@ -708,6 +737,8 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 			if (addonID != id || event.target !== addon) {
 				return;
 			}
+
+			self.@com.lorepo.icplayer.client.module.text.TextView::removeScrollHandlers(Ljava/lang/String;)(scrollNamespace);
 
 			$wnd.MathJax.Hub.getAllJax().forEach(function (mathJaxElement) {
 				mathJaxElement.Detach();
@@ -728,20 +759,20 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 
 		var mockedEvent = {target: addon};
 		var observer = new MutationObserver(function (records) {
-			records.forEach(function (record) {
-				if (record.removedNodes.length) {
-					var id = $wnd.$(record.removedNodes[0]).attr("id");
-					destroy(mockedEvent, id);
+			for (var i = 0; i < records.length; i++) {
+				var removedNodes = records[i].removedNodes;
+				for (var j = 0; j < removedNodes.length; j++) {
+					var removed = removedNodes[j];
+					if (removed === addon || (removed.contains && removed.contains(addon))) {
+						destroy(mockedEvent, id);
+						observer.disconnect();
+						return;
+					}
 				}
-
-				if (record.target.childNodes.length === 0) {
-					observer.disconnect();
-				}
-			});
+			}
 		});
 
-		var config = {childList: true};
-		observer.observe($wnd.$('.ic_page').get(0), config);
+		observer.observe($wnd.document.body, {childList: true, subtree: true});
 	}-*/;
 
 	@Override

--- a/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
+++ b/src/main/java/com/lorepo/icplayer/client/module/text/TextView.java
@@ -711,9 +711,7 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 		];
 	}-*/;
 
-	public native void removeScrollHandlers (String scrollNamespace) /*-{
-		console.log("Execute removeScrollHandlers: " + scrollNamespace);
-		var isCrossDomain = $wnd.self !== $wnd.parent;
+	public native void removeScrollHandlers (String scrollNamespace, boolean isCrossDomain) /*-{
 		var scrollElements = this.@com.lorepo.icplayer.client.module.text.TextView::findScrollElements(Z)(isCrossDomain);
 		var eventName = 'scroll.' + scrollNamespace;
 		try {
@@ -725,7 +723,7 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 		} catch (err) {}
 	}-*/;
 
-	public native void connectDOMNodeRemovedEvent (String id, String scrollNamespace) /*-{
+	public native void connectDOMNodeRemovedEvent (String id, String scrollNamespace, boolean isCrossDomain) /*-{
 		var self = this;
 		var $addon = $wnd.$(".ic_page [id='" + id + "']"),
 			addon = $addon[0];
@@ -738,7 +736,7 @@ public class TextView extends HTML implements IDisplay, IWCAG, MathJaxElement, I
 				return;
 			}
 
-			self.@com.lorepo.icplayer.client.module.text.TextView::removeScrollHandlers(Ljava/lang/String;)(scrollNamespace);
+			self.@com.lorepo.icplayer.client.module.text.TextView::removeScrollHandlers(Ljava/lang/String;Z)(scrollNamespace, isCrossDomain);
 
 			$wnd.MathJax.Hub.getAllJax().forEach(function (mathJaxElement) {
 				mathJaxElement.Detach();

--- a/src/test/java/com/lorepo/icplayer/client/module/text/mockup/TextViewMockup.java
+++ b/src/test/java/com/lorepo/icplayer/client/module/text/mockup/TextViewMockup.java
@@ -168,7 +168,7 @@ public class TextViewMockup implements IDisplay {
 	}
 
 	@Override
-	public void connectDOMNodeRemovedEvent(String id, String scrollNamespace) {
+	public void connectDOMNodeRemovedEvent(String id, String scrollNamespace, boolean isCrossDomain) {
 		// TODO Auto-generated method stub
 	}
 
@@ -178,7 +178,7 @@ public class TextViewMockup implements IDisplay {
 	}
 
 	@Override
-	public void removeScrollHandlers(String scrollNamespace) {
+	public void removeScrollHandlers(String scrollNamespace, boolean isCrossDomain) {
 		// TODO Auto-generated method stub
 	}
 

--- a/src/test/java/com/lorepo/icplayer/client/module/text/mockup/TextViewMockup.java
+++ b/src/test/java/com/lorepo/icplayer/client/module/text/mockup/TextViewMockup.java
@@ -1,5 +1,6 @@
 package com.lorepo.icplayer.client.module.text.mockup;
 
+import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.dom.client.Element;
 import com.lorepo.icplayer.client.metadata.ScoreWithMetadata;
 import com.lorepo.icplayer.client.module.text.*;
@@ -167,7 +168,17 @@ public class TextViewMockup implements IDisplay {
 	}
 
 	@Override
-	public void connectDOMNodeRemovedEvent(String id) {
+	public void connectDOMNodeRemovedEvent(String id, String scrollNamespace) {
+		// TODO Auto-generated method stub
+	}
+
+	@Override
+	public JavaScriptObject findScrollElements(boolean isCrossDomain) {
+		return null;
+	}
+
+	@Override
+	public void removeScrollHandlers(String scrollNamespace) {
 		// TODO Auto-generated method stub
 	}
 

--- a/src/test/java/com/lorepo_patchers/icplayer/client/module/text/TextPresenterPatcher.java
+++ b/src/test/java/com/lorepo_patchers/icplayer/client/module/text/TextPresenterPatcher.java
@@ -11,7 +11,7 @@ public class TextPresenterPatcher {
 	public static void addiOSClassWithTimeout(TextPresenter self, TextPresenter _this) {}
 
     @PatchMethod
-	public static void setupScrollHandlers (TextPresenter self, TextPresenter x, Element e) {}
+	public static void setupScrollHandlers (TextPresenter self, TextPresenter x, Element e, String namespace) {}
 
     @PatchMethod
 	public static boolean isVisibleInViewPort (TextPresenter self, Element e, int scrollTop) {return true;}


### PR DESCRIPTION
Ticket: https://learnetic.youtrack.cloud/issue/PLA-280
Test version: https://test-pla-280-dd-dot-mauthor-dev.ew.r.appspot.com/

Zmiany:
* Dodano czyszczenie nasłuchiwania po zmianie strony lekcji
* Dodano dodatkowe zabezpieczenie w PlayerController.java, aby w przypadku braku $wnd.window.top nie był sprawdzany jego pageYOffset. Do tej sytuacji mogło dojść w przypadku dalej istniejącego nasłuchiwania na elementach rodzicach player'a, gdy player już nie istniał. 