### PR TITLE
Fix using a custom class removes default styles in Points and Lines, re #PLA-293

### DIFF
--- a/addons/PointsLines/src/style.css
+++ b/addons/PointsLines/src/style.css
@@ -1,10 +1,10 @@
-.addon_PointsLines .pointslines {
+.pointslines {
     border: 3px solid #ccc;
     position:absolute;
     -ms-touch-action: none;
     touch-action: none;
 }
-.addon_PointsLines .disabled {
+.pointslines .disabled {
     height: 100%;
     width: 100%;
     background-color: gray;
@@ -12,21 +12,21 @@
     position:absolute;
 }
 
-.addon_PointsLines .correct {
+.pointslines .correct {
     border: 3px solid green;
 }
 
-.addon_PointsLines .wrong {
+.pointslines .wrong {
     border: 3px solid red;
 }
 
-.addon_PointsLines .point_container {
+.pointslines .point_container {
     position: absolute;
     min-height: 25px;
     min-width: 25px;
 }
 
-.addon_PointsLines .point {
+.pointslines .point {
     position: relative;
     height: 16px;
     width: 16px;
@@ -38,31 +38,31 @@
     margin-bottom: -5px;
 }
 
-.addon_PointsLines .selected {
+.pointslines .selected {
     background-color: blue;
 }
 
-.addon_PointsLines .line {
+.pointslines .line {
     position: absolute;
     height:3px;
     background-color: blue;
 }
 
-.addon_PointsLines .line-show-answer {
+.pointslines .line-show-answer {
     position: absolute;
     height:3px;
     background-color: gray;
 }
 
-.addon_PointsLines .noremovable {
+.pointslines .noremovable {
     background-color: black;
 }
 
-.addon_PointsLines .correctLine {
+.pointslines .correctLine {
     background-color: green;
 }
 
-.addon_PointsLines .wrongLine {
+.pointslines .wrongLine {
     background-color: red;
 }
 

--- a/addons/PointsLines/src/style.css
+++ b/addons/PointsLines/src/style.css
@@ -12,11 +12,11 @@
     position:absolute;
 }
 
-.pointslines .correct {
+.pointslines.correct {
     border: 3px solid green;
 }
 
-.pointslines .wrong {
+.pointslines.wrong {
     border: 3px solid red;
 }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2026-05-19 Fixed using a custom class removes default styles in Points and Lines
 2026-05-11 Fixed scroll event handlers in Text module not being removed after lesson's page change
 2026-05-07 Added support for Alternative Texts in the Text Coloring
 2026-04-13 Added support for MathJax in EditableWindow


### PR DESCRIPTION
ticket: https://learnetic.youtrack.cloud/issue/PLA-293
wersja testowa: https://test-pla-293-dot-mauthor-dev.ew.r.appspot.com/present/2316060838715483