### PR TITLE
Fixed ic_selected_module being assigned when keyboard navigation is off, re #PLA-290

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+2026-05-26 Fixed ic_selected_module sometimes being assigned when keyboard navigation is off
 2026-05-22 Fixed using a custom class removes default styles in Points and Lines
 2026-05-20 Added support for old syntax in Plot when decimal separator is a comma
 2026-05-19 Added randomize pages in custom tests

--- a/src/main/java/com/lorepo/icplayer/client/page/KeyboardNavigationController.java
+++ b/src/main/java/com/lorepo/icplayer/client/page/KeyboardNavigationController.java
@@ -242,6 +242,7 @@ public final class KeyboardNavigationController implements IKeyboardNavigationCo
 			}
 		} else {
 			this.deselectCurrentModule();
+			this.savedEntry = null;
 		}
 	}
 
@@ -359,6 +360,7 @@ public final class KeyboardNavigationController implements IKeyboardNavigationCo
 			this.deselectCurrentModule();
 			this.deselectAllModules();
 			this.actualSelectedModuleIndex = 0;
+			this.savedEntry = null;
 		}
 
 	}


### PR DESCRIPTION
ticket: https://learnetic.youtrack.cloud/issue/PLA-290/Support-LeYa-Wizualny-problem-z-nawigacja-klawiaturowa-Shift-Enter
Wersja testowa: https://test-pla-290-dot-mauthor-dev.ew.r.appspot.com/present/1362181196125787